### PR TITLE
First and last page for bootstrap pagination

### DIFF
--- a/integration/bootstrap/dataTables.bootstrap.js
+++ b/integration/bootstrap/dataTables.bootstrap.js
@@ -73,20 +73,33 @@ $.extend( $.fn.dataTableExt.oPagination, {
 				iEnd = iStart + iListLength - 1;
 			}
 
+			var append_page = function(oPaging, an, j) {
+				sClass = (j==oPaging.iPage+1) ? 'class="active"' : '';
+				$('<li '+sClass+'><a href="#">'+j+'</a></li>')
+					.insertBefore( $('li:last', an[i])[0] )
+					.bind('click', function (e) {
+						e.preventDefault();
+						oSettings._iDisplayStart = (parseInt($('a', this).text(),10)-1) * oPaging.iLength;
+						fnDraw( oSettings );
+					} );
+			};
+
 			for ( i=0, ien=an.length ; i<ien ; i++ ) {
 				// Remove the middle elements
 				$('li:gt(0)', an[i]).filter(':not(:last)').remove();
 
+				
+				// Append first page
+				if ( iStart > 1 ) {
+					append_page(oPaging, an, 1);
+				}
 				// Add the new list items and their event handlers
 				for ( j=iStart ; j<=iEnd ; j++ ) {
-					sClass = (j==oPaging.iPage+1) ? 'class="active"' : '';
-					$('<li '+sClass+'><a href="#">'+j+'</a></li>')
-						.insertBefore( $('li:last', an[i])[0] )
-						.bind('click', function (e) {
-							e.preventDefault();
-							oSettings._iDisplayStart = (parseInt($('a', this).text(),10)-1) * oPaging.iLength;
-							fnDraw( oSettings );
-						} );
+					append_page(oPaging, an, j);
+				}
+				// Append last page
+				if ( oPaging.iTotalPages > iEnd ) {
+					append_page(oPaging, an, oPaging.iTotalPages);
 				}
 
 				// Add / remove disabled classes from the static elements


### PR DESCRIPTION
- Display pagination controls as following format: 1,6,7,8,9,10,15 (8 is the active page, 1 is the first page, and 15 is the last page) so the user can have a sense of how many pages there are.
- Factored out append_page function to add more flexibility in adding pages
