### PR TITLE
Extend fnAddTr to allow updating an existing TR node instead of adding

### DIFF
--- a/api/fnAddTr.js
+++ b/api/fnAddTr.js
@@ -1,40 +1,45 @@
 /**
  * Take a TR element and add it to a DataTables table. Useful for maintaining
- * custom classes and other attributes.
+ * custom classes and other attributes. If mRow parameter is set, update
+ * mRow instead of adding a new row.
  *  @name fnAddTr
  *  @anchor fnAddTr
  *  @author <a href="http://sprymedia.co.uk">Allan Jardine</a>
  *
  *  @example
- *    
+ *
  */
 
-$.fn.dataTableExt.oApi.fnAddTr = function ( oSettings, nTr, bRedraw ) {
+$.fn.dataTableExt.oApi.fnAddTr = function ( oSettings, nTr, bRedraw, mRow ) {
     if ( typeof bRedraw == 'undefined' )
     {
         bRedraw = true;
     }
-     
+
     var nTds = nTr.getElementsByTagName('td');
     if ( nTds.length != oSettings.aoColumns.length )
     {
         alert( 'Warning: not adding new TR - columns and TD elements must match' );
         return;
     }
-     
+
     var aData = [];
     for ( var i=0 ; i<nTds.length ; i++ )
     {
         aData.push( nTds[i].innerHTML );
     }
-     
-    /* Add the data and then replace DataTable's generated TR with ours */
-    var iIndex = this.oApi._fnAddData( oSettings, aData );
-    nTr._DT_RowIndex = iIndex;
-    oSettings.aoData[ iIndex ].nTr = nTr;
-     
+
+    if (typeof mRow == 'undefined') {
+        /* Add the data and then replace DataTable's generated TR with ours */
+        var iIndex = this.oApi._fnAddData( oSettings, aData );
+        nTr._DT_RowIndex = iIndex;
+        oSettings.aoData[ iIndex ].nTr = nTr;
+    } else {
+        this.fnUpdate( aData, mRow );
+    }
+
     oSettings.aiDisplay = oSettings.aiDisplayMaster.slice();
-     
+
     if ( bRedraw )
     {
         this.oApi._fnReDraw( oSettings );


### PR DESCRIPTION
Use case is the following: 

Given a DataTable with an actions column. One of the actions changes the row's data via ajax, so that the row actually changed. The ajax request returns a freshly rendered row for the changed entity. To not reload the whole table and lose current filter, pagination or any other settings, the row should be updated.

fnAddTr only allows to add new rows. This patch adds a parameter which can be a TR node or an index, like described in the fnUpdate API. If this parameter is set, the passed node will be updated with the new one.

I'm just not sure if extending fnAddTr is the best idea. Alternatives are: 
1. Rename fnAddTr to something more descriptive
2. Instead of modifying fnAddTr, add a new plugin fnUpdateTr. That'll mean code duplication, as the code would be nearly the same as fnAddTr.

What do you think?
