### PR TITLE
Fix two issues in  ellipsis pagination

### DIFF
--- a/pagination/ellipses.js
+++ b/pagination/ellipses.js
@@ -95,7 +95,7 @@ $.fn.dataTableExt.oPagination.ellipses = {
             $('.' + oClasses.sPagePrevious, tableWrapper).removeAttr('disabled');
         }
 
-        if (oSettings._iCurrentPage === oSettings._iTotalPages) {
+        if (oSettings._iTotalPages === 0 || oSettings._iCurrentPage === oSettings._iTotalPages) {
             $('.' + oClasses.sPageNext, tableWrapper).attr('disabled', true);
             $('.' + oClasses.sPageLast, tableWrapper).attr('disabled', true);
         } else {


### PR DESCRIPTION
Fixed two issues.
- Button selector(prev, first, next, last) will change all datatables instances in current page.
- Next/last page buttons are not disabled if no records in table.
