### PR TITLE
Pagination broken on latest foundation (4.2.3) when switching pages

### DIFF
--- a/integration/foundation/dataTables.foundation.js
+++ b/integration/foundation/dataTables.foundation.js
@@ -119,7 +119,7 @@ $.extend( $.fn.dataTableExt.oPagination, {
 				$('li:gt(0)', an[i]).filter(':not(:last)').remove();
 
 				// Add the new list items and their event handlers
-				$.each( pages, function( i, page ) {
+				$.each( pages, function( ii, page ) {
 					klass = page === null ? 'unavailable' :
 						page === oPaging.iPage ? 'current' : '';
 					$('<li class="'+klass+'"><a href="">'+(page===null? '&hellip;' : page+1)+'</a></li>')


### PR DESCRIPTION
Pagination broken on latest foundation (4.2.3) when switching pages and there is another ul element on the page, seems to break from the "fnupdate" function. 

The container for the page numbers is set to undefined so the page numbers get added to the first unordered list found on the page.
