### PR TITLE
Update fnAddTr.js - Fix - Showing invisible columns - 

### DIFF
--- a/api/fnAddTr.js
+++ b/api/fnAddTr.js
@@ -23,11 +23,21 @@ $.fn.dataTableExt.oApi.fnAddTr = function ( oSettings, nTr, bRedraw ) {
     }
      
     var aData = [];
+    var aInvisible = [];
     for ( var i=0 ; i<nTds.length ; i++ )
     {
         aData.push( nTds[i].innerHTML );
+        if (!oSettings.aoColumns[i].bVisible)
+        {
+            aInvisible.push( i );
+        }
     }
-     
+    
+    for ( var i = (aInvisible.length - 1) ; i >= 0 ; i-- )
+    {
+        nTds[aInvisible[i]].remove();
+    }
+
     /* Add the data and then replace DataTable's generated TR with ours */
     var iIndex = this.oApi._fnAddData( oSettings, aData );
     nTr._DT_RowIndex = iIndex;


### PR DESCRIPTION
Showing not visible columns and returning the result of fnAddData, now using the actual TR.
Also fixes the problem described at [#24](https://github.com/DataTables/Plugins/pull/24):

> Okay - I agree - there is an issue here. This pull request isn't quite the right fix for the issue, so I'll not pull it in, and I'm not going to look at it myself as it should be addressed in 1.10 - but yes, there is an issue with this existing plug-in that if yourself or anyone else wishes to fix, whereby the added TR is kept, then I'll happily pull it in.
> 
> Good to hear that the plug-in works for you though :-)
