### PR TITLE
Update fnAddTr.js - Fix - Showing invisible columns - Adding the TD to the hidden element list (_anHidden)

### DIFF
--- a/api/fnAddTr.js
+++ b/api/fnAddTr.js
@@ -14,14 +14,14 @@ $.fn.dataTableExt.oApi.fnAddTr = function ( oSettings, nTr, bRedraw ) {
     {
         bRedraw = true;
     }
-     
+
     var nTds = nTr.getElementsByTagName('td');
     if ( nTds.length != oSettings.aoColumns.length )
     {
         alert( 'Warning: not adding new TR - columns and TD elements must match' );
         return;
     }
-     
+
     var aData = [];
     var aInvisible = [];
     for ( var i=0 ; i<nTds.length ; i++ )
@@ -32,19 +32,22 @@ $.fn.dataTableExt.oApi.fnAddTr = function ( oSettings, nTr, bRedraw ) {
             aInvisible.push( i );
         }
     }
-    
-    for ( var i = (aInvisible.length - 1) ; i >= 0 ; i-- )
-    {
-        nTds[aInvisible[i]].remove();
-    }
 
     /* Add the data and then replace DataTable's generated TR with ours */
     var iIndex = this.oApi._fnAddData( oSettings, aData );
     nTr._DT_RowIndex = iIndex;
     oSettings.aoData[ iIndex ].nTr = nTr;
-     
+
     oSettings.aiDisplay = oSettings.aiDisplayMaster.slice();
-     
+
+    // Hidding invisible columns
+    for ( var i = (aInvisible.length - 1) ; i >= 0 ; i-- )
+    {
+		oSettings.aoData[iIndex]._anHidden[ i ] = nTds[aInvisible[i]];
+		nTr.removeChild( nTds[aInvisible[i]] );
+    }
+
+	// Redraw
     if ( bRedraw )
     {
         this.oApi._fnReDraw( oSettings );


### PR DESCRIPTION
Showing not visible columns and returning the result of fnAddData, now using the actual TR.
Also fixes the problem described at [#24](https://github.com/DataTables/Plugins/pull/24):

> Okay - I agree - there is an issue here. This pull request isn't quite the right fix for the issue, so I'll not pull it in, and I'm not going to look at it myself as it should be addressed in 1.10 - but yes, there is an issue with this existing plug-in that if yourself or anyone else wishes to fix, whereby the added TR is kept, then I'll happily pull it in.
> 
> Good to hear that the plug-in works for you though :-)

And [#26](https://github.com/DataTables/Plugins/pull/26):

> I'm afraid this still isn't quite right - it needs to put the hidden cell nodes into an array like fnSetColumnVis does so they can be readied in future: https://github.com/DataTables/DataTables/blob/master/media/src/api/api.methods.js#L1097
