### PR TITLE
Added plugin to hijack length menu into a length + all/selected items.

### DIFF
--- a/filtering/row-based/TableTools.ShowSelectedOnly.js
+++ b/filtering/row-based/TableTools.ShowSelectedOnly.js
@@ -154,7 +154,7 @@
         "fnInit": function (oSettings) {
             return new $.fn.dataTable.SelectedLengthMenu(oSettings);
         },
-        "cFeature": "S",
+        "cFeature": "O",
         "sFeature": "SelectedLengthMenu"
     });
     


### PR DESCRIPTION
Uses the default length menu code and adds another select to it that filters between all and selected rows when using row selection provided by TableTools.

sLengthMenu still works, just use _SELECTEDMENU_ for the new dropdown, but the filter currently requires it to be named '<tableID>_selectedFilter'

oLanguage.oFilterSelectedOptions allows you to specify the text for the dropdown. AllText and SelectedText are the required property names (or supply strings as an array in that order).

I also certify that this Works on My Machine ;)
