### PR TITLE
Foundation pagination: Do not navigate to unparseable page numbers.

### DIFF
--- a/integration/foundation/dataTables.foundation.js
+++ b/integration/foundation/dataTables.foundation.js
@@ -127,8 +127,11 @@ $.extend( $.fn.dataTableExt.oPagination, {
 						.insertBefore( $('li:last', host) )
 						.bind('click', function (e) {
 							e.preventDefault();
-							oSettings._iDisplayStart = (parseInt($('a', this).text(),10)-1) * oPaging.iLength;
-							fnDraw( oSettings );
+							var pageNum = parseInt($('a', this).text(),10);
+							if ( ! isNaN(pageNum)) {
+								oSettings._iDisplayStart = (pageNum-1) * oPaging.iLength;
+								fnDraw( oSettings );
+							}
 						} );
 				} );
 


### PR DESCRIPTION
Clicking on an ellipsis in the foundation pagination causes the user no navigate to a NaN page. Pull request now parses the page number in the item click event first, before navigating.

Fixes #22
