### PR TITLE
Update datetime-us.js

### DIFF
--- a/sorting/datetime-us.js
+++ b/sorting/datetime-us.js
@@ -27,7 +27,7 @@ jQuery.extend(jQuery.fn.dataTableExt.oSort, {
             year = b[3],
             hour = b[4],
             min = b[5],
-            ap = b[6];
+            ap = b[6].toLowerCase();
 
         if (hour == '12') {
             hour = '0';


### PR DESCRIPTION
Datetime regex matches with PM/Pm/pm, but only takes it into account in calculation if "pm" is provided, causing sorting bugs in certain cases.  Forcing to lowercase when parsing fixes this issue.
