### PR TITLE
Typo fixed in German i18n file

### DIFF
--- a/i18n/German.lang
+++ b/i18n/German.lang
@@ -9,7 +9,7 @@
 	"sEmptyTable":   	"Keine Daten in der Tabelle vorhanden",
 	"sInfo":         	"_START_ bis _END_ von _TOTAL_ Einträgen",
 	"sInfoEmpty":    	"0 bis 0 von 0 Einträgen",
-	"sInfoFiltered": 	"(gefiltert von _MAX_  Einträgen)",
+	"sInfoFiltered": 	"(gefiltert von _MAX_ Einträgen)",
 	"sInfoPostFix":  	"",
 	"sInfoThousands":  	".",
 	"sLengthMenu":   	"_MENU_ Einträge anzeigen",


### PR DESCRIPTION
Removed a doubled space.
