### PR TITLE
Polish (PL) translation cleanups.

### DIFF
--- a/i18n/Polish.lang
+++ b/i18n/Polish.lang
@@ -6,9 +6,10 @@
  */
 
 {
-	"sProcessing":   "Proszę czekać...",
+	"sProcessing":   "Przetwarzanie...",
 	"sLengthMenu":   "Pokaż _MENU_ pozycji",
-	"sZeroRecords":  "Nie znaleziono żadnych pasujących indeksów",
+	"sZeroRecords":  "Nie znaleziono pasujących pozycji",
+	"sInfoThousands":  " ",
 	"sInfo":         "Pozycje od _START_ do _END_ z _TOTAL_ łącznie",
 	"sInfoEmpty":    "Pozycji 0 z 0 dostępnych",
 	"sInfoFiltered": "(filtrowanie spośród _MAX_ dostępnych pozycji)",
@@ -16,10 +17,10 @@
 	"sSearch":       "Szukaj:",
 	"sUrl":          "",
 	"oPaginate": {
-	"sFirst":    "Pierwsza",
-	"sPrevious": "Poprzednia",
-	"sNext":     "Następna",
-	"sLast":     "Ostatnia"
+		"sFirst":    "Pierwsza",
+		"sPrevious": "Poprzednia",
+		"sNext":     "Następna",
+		"sLast":     "Ostatnia"
 	},
 	"sEmptyTable":     "Brak danych",
 	"sLoadingRecords": "Wczytywanie...",


### PR DESCRIPTION
Fixed indentation.
Corrected 2 translations - to shorter and more appriopriate (I think) versions.
Added thousands separator - single space.
