### PR TITLE
Remove "modal" from DTTT_print_info

### DIFF
--- a/integration/bootstrap/3/dataTables.bootstrap.js
+++ b/integration/bootstrap/3/dataTables.bootstrap.js
@@ -116,7 +116,7 @@ DataTable.ext.renderer.pageButton.bootstrap = function ( settings, host, idx, bu
 					settings.oApi._fnBindAction(
 						node, {action: button}, clickHandler
 					);
-				}
+				}f
 			}
 		}
 	};
@@ -148,7 +148,7 @@ if ( DataTable.TableTools ) {
 			}
 		},
 		"print": {
-			"info": "DTTT_print_info modal"
+			"info": "DTTT_print_info"
 		},
 		"select": {
 			"row": "active"


### PR DESCRIPTION
I was having some issues with the "copy" and "print" modal not appearing when using Bootstrap 3. It seems there were some changes made to modal in 3 that conflict. 

Unfortunately the examples section on the official website is broken:
https://datatables.net/release-datatables/extensions/TableTools/examples/bootstrap.html

But I made this plunker: 
http://plnkr.co/edit/HuOy77MurrLcE3g8ECUj?p=preview

I don't like modifying the source, so I'm just extending the DataTable.TableTools.classes and the info box now works. I'm not sure if removing "modal" is the correct bootstrappy solution, but it was easier for me to overwrite than the javascript. The correct solution might be in the fading work done here: https://github.com/DataTables/TableTools/blob/master/js/dataTables.tableTools.js but I'm not sure.
