### PR TITLE
wrapped grid class .row around main datatable in DOM options

### DIFF
--- a/integration/bootstrap/3/dataTables.bootstrap.js
+++ b/integration/bootstrap/3/dataTables.bootstrap.js
@@ -19,8 +19,8 @@ var factory = function( $, DataTable ) {
 /* Set the defaults for DataTables initialisation */
 $.extend( true, DataTable.defaults, {
 	dom:
-		"<'row'<'col-xs-6'l><'col-xs-6'f>r>"+
-		"t"+
+		"<'row'<'col-xs-6'l><'col-xs-6'f>r>" +
+		"<'row'<'col-xs-12't>>" +
 		"<'row'<'col-xs-6'i><'col-xs-6'p>>",
 	renderer: 'bootstrap'
 } );


### PR DESCRIPTION
Modified DataTable DOM setting to be more compliant and consistent with Bootstrap grid specifications.  

See code line comments for further details.
