### PR TITLE
Add margin-left to search input box

### DIFF
--- a/integration/bootstrap/3/dataTables.bootstrap.css
+++ b/integration/bootstrap/3/dataTables.bootstrap.css
@@ -15,6 +15,7 @@ div.dataTables_filter label {
 
 div.dataTables_filter input {
 	width: 16em;
+	margin-left: 0.5em;
 }
 
 div.dataTables_info {


### PR DESCRIPTION
This margin exists in the default dataTables CSS but was missing from the dataTables bootstrap CSS.  It adds a small gap between the "Search:" label and the search input box.
