### PR TITLE
TableTools styles shouldn't override default BS styles

### DIFF
--- a/integration/bootstrap/3/dataTables.bootstrap.css
+++ b/integration/bootstrap/3/dataTables.bootstrap.css
@@ -131,24 +131,24 @@ div.dataTables_scrollHead table.table-bordered {
 /*
  * TableTools styles
  */
-.table tbody tr.active td,
-.table tbody tr.active th {
+.table.dataTable tbody tr.active td,
+.table.dataTable tbody tr.active th {
 	background-color: #08C;
 	color: white;
 }
 
-.table tbody tr.active:hover td,
-.table tbody tr.active:hover th {
+.table.dataTable tbody tr.active:hover td,
+.table.dataTable tbody tr.active:hover th {
 	background-color: #0075b0 !important;
 }
 
-.table tbody tr.active th > a,
-.table tbody tr.active td > a {
+.table.dataTable tbody tr.active th > a,
+.table.dataTable tbody tr.active td > a {
 	color: white;
 }
 
-.table-striped tbody tr.active:nth-child(odd) td,
-.table-striped tbody tr.active:nth-child(odd) th {
+.table-striped.dataTable tbody tr.active:nth-child(odd) td,
+.table-striped.dataTable tbody tr.active:nth-child(odd) th {
 	background-color: #017ebc;
 }
 


### PR DESCRIPTION
I've recently noticed that TableTools styles override the original Bootstrap table classes (like **`.active`**).
This should happen only on tables with dataTable plugin enabled, not the "non-extended" ones.
