### PR TITLE
Update bootstrap pagination events to not redraw when button is disabled

### DIFF
--- a/integration/bootstrap/3/dataTables.bootstrap.js
+++ b/integration/bootstrap/3/dataTables.bootstrap.js
@@ -45,7 +45,7 @@ DataTable.ext.renderer.pageButton.bootstrap = function ( settings, host, idx, bu
 		var i, ien, node, button;
 		var clickHandler = function ( e ) {
 			e.preventDefault();
-			if ( e.data.action !== 'ellipsis' ) {
+			if ( !$(e.currentTarget).hasClass('disabled') ) {
 				api.page( e.data.action ).draw( false );
 			}
 		};


### PR DESCRIPTION
When using server-side pagination with the bootstrap plugin the previous/next buttons still trigger an ajax request when disabled. This pull request fixes this issue by preventing the table from being redrawn when the clicked button has the css class "disabled". This handles the pagination button "disabled" use cases for the ellipsis, previous, and next pagination buttons.
