### PR TITLE
Punctuation error in Polish translation

### DIFF
--- a/i18n/Polish.lang
+++ b/i18n/Polish.lang
@@ -25,7 +25,7 @@
 	"sEmptyTable":     "Brak danych",
 	"sLoadingRecords": "Wczytywanie...",
 	"oAria": {
-		"sSortAscending":  ": aktywuj by posortować kolumnę rosnąco",
-		"sSortDescending": ": aktywuj by posortować kolumnę malejąco"
+		"sSortAscending":  ": aktywuj, by posortować kolumnę rosnąco",
+		"sSortDescending": ": aktywuj, by posortować kolumnę malejąco"
 	}
 }


### PR DESCRIPTION
Just two lacking commas. Here's link to appropriate punctuation rules (in Polish only): http://so.pwn.pl/zasady.php?id=629774.
