### PR TITLE
always show the pagination markup after rendering

### DIFF
--- a/pagination/input.js
+++ b/pagination/input.js
@@ -215,6 +215,8 @@ $.fn.dataTableExt.oPagination.input = {
 		        spans[3].innerHTML = " of " + iPages;
 		        inputs[0].value = iCurrentPage;
 		    }
+		    
+    		    $(an).show();
 		}
 	}
 };


### PR DESCRIPTION
Always show the pagination markup when rendering since it might already be hidden from previous checks for page sizes. An issue when using ajax since the total number of records isn't available when the plugin is initialised, causing the markup to be hidden permanently.
