### PR TITLE
Broken output fix

### DIFF
--- a/pagination/select.js
+++ b/pagination/select.js
@@ -89,7 +89,7 @@ $.fn.dataTableExt.oPagination.listbox = {
 						elSel.add(oOption); // IE only
 					}
 				}
-				spans[1].innerHTML = " nbsp;of nbsp;" + iPages;
+				spans[1].innerHTML = "&nbsp;of&nbsp;" + iPages;
 			}
 		  elSel.value = iCurrentPage;
 		}


### PR DESCRIPTION
Incorrect usage of `&nbsp;`
