### PR TITLE
Allowing Bootstrap to determine button text color

### DIFF
--- a/integration/bootstrap/3/dataTables.bootstrap.css
+++ b/integration/bootstrap/3/dataTables.bootstrap.css
@@ -175,7 +175,6 @@ table.DTTT_selectable tbody tr {
 }
 
 div.DTTT .btn {
-	color: #333 !important;
 	font-size: 12px;
 }
 


### PR DESCRIPTION
This style was preventing Bootstrap from determining the proper text color for buttons. For instance, if the user set the class of a TableTools button to btn-primary, the button would be properly styled but would have a dark grey font color instead of white. Removing this line resolves the issue.
