### PR TITLE
Update Russian lang file for DataTables >= 1.10

### DIFF
--- a/i18n/Russian.lang
+++ b/i18n/Russian.lang
@@ -3,26 +3,28 @@
  *  @name Russian
  *  @anchor Russian
  *  @author Tjoma
+ *  @autor aspyatkin 
  */
 
 {
-	"sProcessing":   "Подождите...",
-	"sLengthMenu":   "Показать _MENU_ записей",
-	"sZeroRecords":  "Записи отсутствуют.",
-	"sInfo":         "Записи с _START_ до _END_ из _TOTAL_ записей",
-	"sInfoEmpty":    "Записи с 0 до 0 из 0 записей",
-	"sInfoFiltered": "(отфильтровано из _MAX_ записей)",
-	"sInfoPostFix":  "",
-	"sSearch":       "Поиск:",
-	"sUrl":          "",
-	"oPaginate": {
-		"sFirst": "Первая",
-		"sPrevious": "Предыдущая",
-		"sNext": "Следующая",
-		"sLast": "Последняя"
-	},
-	"oAria": {
-		"sSortAscending":  ": активировать для сортировки столбца по возрастанию",
-		"sSortDescending": ": активировать для сортировки столбцов по убыванию"
-	}
+  "processing": "Подождите...",
+  "search": "Поиск:",
+  "lengthMenu": "Показать _MENU_ записей",
+  "info": "Записи с _START_ до _END_ из _TOTAL_ записей",
+  "infoEmpty": "Записи с 0 до 0 из 0 записей",
+  "infoFiltered": "(отфильтровано из _MAX_ записей)",
+  "infoPostFix": "",
+  "loadingRecords": "Загрузка записей...",
+  "zeroRecords": "Записи отсутствуют.",
+  "emptyTable:": "В таблице отсутствуют данные",
+  "paginate": {
+    "first": "Первая",
+    "previous": "Предыдущая",
+    "next": "Следующая",
+    "last": "Последняя"
+  },
+  "aria": {
+    "sortAscending": ": активировать для сортировки столбца по возрастанию",
+    "sortDescending": ": активировать для сортировки столбца по убыванию"
+  }
 }


### PR DESCRIPTION
1. As it said in DataTables blog, camelCase notation is preferred over Hungarian one from 1.10.
2. Previous translation doesn't contain loadingRecords (or sLoadingRecords) translation

P.S. Really don't like vertically aligned lines
