### PR TITLE
Allow Bootstrap to determine button font size

### DIFF
--- a/integration/bootstrap/3/dataTables.bootstrap.css
+++ b/integration/bootstrap/3/dataTables.bootstrap.css
@@ -174,10 +174,6 @@ table.DTTT_selectable tbody tr {
 	cursor: pointer;
 }
 
-div.DTTT .btn {
-	font-size: 12px;
-}
-
 div.DTTT .btn:hover {
 	text-decoration: none !important;
 }


### PR DESCRIPTION
Setting a static font size here causes DataTables buttons to have different font size to the regular bootstrap buttons.
