### PR TITLE
Bower install instruction added

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,9 @@ This repository holds the following plug-in types for DataTables:
   * Twitter Bootstrap
 
 Each directory has an index.html file which is used to generate the plug-ins documentation on [DataTables.net](http://datatables.net/plug-ins) and describes how plug-ins can be used.
+
+
+## Install via Bower package manager
+
+```
+$ bower install --save datatables-plugins


### PR DESCRIPTION
- As `datatables-plugins` in present in bower and bower being popular static files manager now-a-days, it's information has been added.
- Developers normally looks for bower install information to get the dependency, as I was.
- Hope it would be useful.
