### PR TITLE
FIX: Considering the milliseconds for ordering

### DIFF
--- a/sorting/datetime-moment.js
+++ b/sorting/datetime-moment.js
@@ -41,7 +41,7 @@ $.fn.dataTable.moment = function ( format, locale ) {
 	types.order[ 'moment-'+format+'-pre' ] = function ( d ) {
 		return d === '' || d === null ?
 			-Infinity :
-			moment( d, format, locale, true ).unix();
+			parseInt( moment( d, format, locale, true ).format( 'x' ), 10 );
 	};
 };
 


### PR DESCRIPTION
I have to order timestamp with milliseconds. But using your plugins, sorting doesn't work properly because you use the function unix() which returns a epoch timestamp in seconds, not in milliseconds.

I've patched it. 