### PR TITLE
Sorting dates when date is inside a link

### DIFF
--- a/sorting/datetime-moment.js
+++ b/sorting/datetime-moment.js
@@ -20,6 +20,12 @@
  *    $('#example').DataTable();
  */
 
+function strip(html) {
+   var tmp = document.createElement("DIV");
+   tmp.innerHTML = html;
+   return tmp.textContent || tmp.innerText || "";
+}
+
 (function($) {
 
 $.fn.dataTable.moment = function ( format, locale ) {
@@ -32,7 +38,7 @@ $.fn.dataTable.moment = function ( format, locale ) {
 			return 'moment-'+format;
 		}
 
-		return moment( d, format, locale, true ).isValid() ?
+		return moment( strip(d), format, locale, true ).isValid() ?
 			'moment-'+format :
 			null;
 	} );
@@ -41,7 +47,7 @@ $.fn.dataTable.moment = function ( format, locale ) {
 	types.order[ 'moment-'+format+'-pre' ] = function ( d ) {
 		return d === '' || d === null ?
 			-Infinity :
-			parseInt( moment( d, format, locale, true ).format( 'x' ), 10 );
+			parseInt( moment( strip(d), format, locale, true ).format( 'x' ), 10 );
 	};
 };
 


### PR DESCRIPTION
The issue is seen on http://jsfiddle.net/dnsL2oc4/1/ (with the current `datetime-moment.js`): it is impossible to properly sort the dates since they're inside a link. Instead, the link (`a href`) is used to perform sorting.
The solution can be found on http://jsfiddle.net/dnsL2oc4/2/ and is reflected in this pull request.

See http://stackoverflow.com/questions/28864853/ for background.