### PR TITLE
Bug Fix: Input pager stuck in hidden state if initially hidden

### DIFF
--- a/pagination/input.js
+++ b/pagination/input.js
@@ -207,7 +207,7 @@ $.fn.dataTableExt.oPagination.input = {
 		}
 		else
 		{
-			$(an).hide();
+			$(an).show();
 
 			/* Loop over each instance of the pager */
 			for (var i = 0, iLen = an.length ; i < iLen ; i++)

--- a/pagination/input.js
+++ b/pagination/input.js
@@ -207,6 +207,8 @@ $.fn.dataTableExt.oPagination.input = {
 		}
 		else
 		{
+			$(an).hide();
+
 			/* Loop over each instance of the pager */
 			for (var i = 0, iLen = an.length ; i < iLen ; i++)
 			{


### PR DESCRIPTION
Input Pager, if initially hidden, remains hidden on subsequent updates regardless of page count.

Added line to show pager if count >= 1.