### PR TITLE
Add: rowsGroup plugin as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "features/rowsGroup"]
+	path = features/rowsGroup
+	url = https://github.com/ashl1/datatables-rowsgroup


### PR DESCRIPTION
The RowsGroup plugin located in https://github.com/ashl1/datatables-rowsgroup as a git submodule
