### PR TITLE
changed usage to require-friendly amd style for datetime-moment plugin

### DIFF
--- a/sorting/datetime-moment.js
+++ b/sorting/datetime-moment.js
@@ -20,7 +20,13 @@
  *    $('#example').DataTable();
  */
 
-(function($) {
+(function (factory) {
+	if (typeof define === "function" && define.amd) {
+		define(["jquery", "moment", "datatables"], factory);
+	} else {
+		factory(jQuery, moment);
+	}
+}(function ($, moment) {
 
 $.fn.dataTable.moment = function ( format, locale ) {
 	var types = $.fn.dataTable.ext.type;
@@ -50,4 +56,4 @@ $.fn.dataTable.moment = function ( format, locale ) {
 	};
 };
 
-}(jQuery));
+}));


### PR DESCRIPTION
It can cause problems with moment in future for non-requireJS usage only, coz "In 2.4.0, the globally exported moment object was deprecated. It will be removed in next major release."