### PR TITLE
- not sure if this is the fix

### DIFF
--- a/sorting/datetime-moment.js
+++ b/sorting/datetime-moment.js
@@ -49,7 +49,7 @@ $.fn.dataTable.moment = function ( format, locale ) {
 	} );
 
 	// Add sorting method - use an integer for the sorting
-	types.order[ 'moment-'+format+'-pre' ] = function ( d ) {
+	types.order[ 'moment-'+format ] = function ( d ) {
 		return d === '' || d === null ?
 			-Infinity :
 			parseInt( moment( d.replace ? d.replace(/<.*?>/g, '') : d, format, locale, true ).format( 'x' ), 10 );


### PR DESCRIPTION
Chrome seem to have trouble with the sorting. 
It is ordering pm first with this format of date time D/M/YYYY,  h:m a on an ascending order

line 47 had 'moment-'+format
we do not need that '-pre'