### PR TITLE
Improve sorting for dates without hours

### DIFF
--- a/sorting/date-euro.js
+++ b/sorting/date-euro.js
@@ -27,7 +27,7 @@
 
         if ( $.trim(a) !== '' ) {
             var frDatea = $.trim(a).split(' ');
-            var frTimea = frDatea[1].split(':');
+            var frTimea = (undefined != frDatea[1]) ? frDatea[1].split(':') : [00,00,00];
             var frDatea2 = frDatea[0].split('/');
             x = (frDatea2[2] + frDatea2[1] + frDatea2[0] + frTimea[0] + frTimea[1] + frTimea[2]) * 1;
         }


### PR DESCRIPTION
This modification allow to sort dates in formet DD/MM/YYYY as well as
dates in format DD/MM/YYYY HH:II:SS without error « frDatea[1] undefined
» on line 30