### PR TITLE
Sorting does not work properly on columns with empty dates inside HTML tags

### DIFF
--- a/sorting/datetime-moment.js
+++ b/sorting/datetime-moment.js
@@ -50,9 +50,12 @@ $.fn.dataTable.moment = function ( format, locale ) {
 
 	// Add sorting method - use an integer for the sorting
 	types.order[ 'moment-'+format+'-pre' ] = function ( d ) {
+		if ( d && d.replace ) {
+			d = d.replace(/<.*?>/g, '');
+		}
 		return d === '' || d === null ?
 			-Infinity :
-			parseInt( moment( d.replace ? d.replace(/<.*?>/g, '') : d, format, locale, true ).format( 'x' ), 10 );
+			parseInt( moment( d, format, locale, true ).format( 'x' ), 10 );
 	};
 };
 


### PR DESCRIPTION
If you have columns with dates inside HTML tags, and some of those date values are empty, sorting does not work properly. 
The column type is identified properly due to the changes introduced by commit 0f8ec6f7, but the sorting still does not work.
This pull request reuses the same strategy of that commit on sorting.