### PR TITLE
Added new multipliers in order to include *bibyte units during sorting

### DIFF
--- a/sorting/file-size.js
+++ b/sorting/file-size.js
@@ -23,10 +23,15 @@ jQuery.fn.dataTable.ext.type.order['file-size-pre'] = function ( data ) {
     var multipliers = {
         b:  1,
         kb: 1000,
+        kib: 1024,
         mb: 1000000,
+        mib: 1048576,
         gb: 1000000000,
+        gib: 1073741824,
         tb: 1000000000000,
-        pb: 1000000000000000
+        tib: 1099511627776,
+        pb: 1000000000000000,
+        pib: 1125899906842624
     };
 
     if (matches) {


### PR DESCRIPTION
Just added some new multipliers to include *bibyte units (Kibibytes, Mebibytes, etc) while sorting by file size.