### PR TITLE
Added Norwegian Nynorsk in addition to current Norwegian Bokmål translation

### DIFF
--- a/i18n/Norwegian-Bokmal.lang
+++ b/i18n/Norwegian-Bokmal.lang
@@ -1,7 +1,7 @@
 /**
- * Norwegian translation
- *  @name Norwegian
- *  @anchor Norwegian
+ * Norwegian Bokmål translation
+ *  @name Norwegian-Bokmal
+ *  @anchor Norwegian-Bokmal
  *  @author Petter Ekrann
  *  @author Vegard Johannessen
  */

--- a/i18n/Norwegian-Nynorsk.lang
+++ b/i18n/Norwegian-Nynorsk.lang
@@ -1,0 +1,33 @@
+/**
+ * Norwegian Nynorsk translation
+ *  @name Norwegian-Nynorsk
+ *  @anchor Norwegian-Nynorsk
+ *  @author Andreas-Johann Østerdal Ulvestad
+ */
+
+
+{
+    "sEmptyTable": "Inga data tilgjengeleg i tabellen",
+    "sInfo": "Syner _START_ til _END_ av _TOTAL_ linjer",
+    "sInfoEmpty": "Syner 0 til 0 av 0 linjer",
+    "sInfoFiltered": "(filtrert frå _MAX_ totalt antal linjer)",
+    "sInfoPostFix": "",
+    "sInfoThousands": " ",
+    "sLoadingRecords": "Lastar...",
+    "sLengthMenu": "Syn _MENU_ linjer",
+    "sLoadingRecords": "Lastar...",
+    "sProcessing": "Lastar...",
+    "sSearch": "S&oslash;k:",
+    "sUrl": "",
+    "sZeroRecords": "Inga linjer treff p&aring; s&oslash;ket",
+    "oPaginate": {
+        "sFirst": "Fyrste",
+        "sPrevious": "Forrige",
+        "sNext": "Neste",
+        "sLast": "Siste"
+    }
+    "oAria": {
+        "sSortAscending": ": aktiver for å sortere kolonna stigande",
+        "sSortDescending": ": aktiver for å sortere kolonna synkande"
+    }
+}


### PR DESCRIPTION
There are two written forms of Norwegian: Norwegian bokmål and Norwegian nynorsk. These two forms are equal in rank.

Norwegian Bokmål (which was the current Norwegian translation for Datatables) should be classified as Norwegian Bokmål, not Norwegian.

Also, added Norwegian Nynorsk translation.