### PR TITLE
dataTables.scrollResize.js

### DIFF
--- a/features/scrollResize/dataTables.scrollResize.js
+++ b/features/scrollResize/dataTables.scrollResize.js
@@ -77,7 +77,7 @@ ScrollResize.prototype = {
 		availableHeight -= offsetTop;
 		availableHeight -= settings.container.height() - ( offsetTop + scrollBody.height() );
 
-		$('div.dataTables_scrollBody').css( {
+		$('div.dataTables_scrollBody', t.container()).css( {
 			maxHeight: availableHeight,
 			height: availableHeight
 		} );


### PR DESCRIPTION
Missing context on _size function. Resulting in errors, when using multiple tables