### PR TITLE
Fix standard input pagination calculation

### DIFF
--- a/pagination/input.js
+++ b/pagination/input.js
@@ -157,7 +157,7 @@
 					iNewStart = 0;
 				}
 				if (iNewStart >= oSettings.fnRecordsDisplay()) {
-					iNewStart = (Math.ceil((oSettings.fnRecordsDisplay() - 1) / oSettings._iDisplayLength) - 1) * oSettings._iDisplayLength;
+					iNewStart = (Math.ceil((oSettings.fnRecordsDisplay()) / oSettings._iDisplayLength) - 1) * oSettings._iDisplayLength;
 				}
 
 				oSettings._iDisplayStart = iNewStart;


### PR DESCRIPTION
Fixes #275 

Seems like someone was confused about the `-1` that's necessary in other cases as pages internally start with 0.