### PR TITLE
Fix enum plugin to be standard compatible

### DIFF
--- a/sorting/enum.js
+++ b/sorting/enum.js
@@ -24,7 +24,9 @@
 var unique = 0;
 var types = $.fn.dataTable.ext.type;
 
-$.fn.dataTable.enum = function ( arr ) {
+// Using form $.fn.dataTable.enum breaks at least YuiCompressor since enum is
+// a reserved word in JavaScript
+$.fn.dataTable['enum'] = function ( arr ) {
 	var name = 'enum-'+(unique++);
 	var lookup = window.Map ? new Map() : {};
 


### PR DESCRIPTION
The word `enum` is is a reserved JavaScript word and form
$.fn.dataTable.enum broke at least YuiCompressor minification

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datatables/plugins/282)
<!-- Reviewable:end -->
