### PR TITLE
Add Pashto translation

### DIFF
--- a/i18n/Pashto.lang
+++ b/i18n/Pashto.lang
@@ -1,0 +1,30 @@
+/**
+ * Pashto translation
+ *  @name Pashto
+ *  @anchor Pashto
+ *  @author <a href="http://mbrig.com/">MBrig | Muhammad Nasir Rahimi</a>
+ */
+
+{
+	"sEmptyTable":     "جدول خالي دی",
+	"sInfo":           "د _START_ څخه تر _END_ پوري، له ټولو _TOTAL_ څخه",
+	"sInfoEmpty":      "د 0 څخه تر 0 پوري، له ټولو 0 څخه",
+	"sInfoFiltered":   "(لټول سوي له ټولو _MAX_ څخه)",
+	"sInfoPostFix":    "",
+	"sInfoThousands":  ",",
+	"sLengthMenu":     "_MENU_ کتاره وښايه",
+	"sLoadingRecords": "منتظر اوسئ...",
+	"sProcessing":     "منتظر اوسئ...",
+	"sSearch":         "لټون:",
+	"sZeroRecords":    "د لټون مطابق معلومات و نه موندل سول",
+	"oPaginate": {
+		"sFirst":    "لومړۍ",
+		"sLast":     "وروستۍ",
+		"sNext":     "بله",
+		"sPrevious": "شاته"
+	},
+	"oAria": {
+		"sSortAscending":  ": په صعودي ډول مرتبول",
+		"sSortDescending": ": په نزولي ډول مرتبول"
+	}
+}


### PR DESCRIPTION
Pashto translation plugin for DataTables
Note: For sure you can release it under MIT license.