### PR TITLE
Changed datetime-moment to strip out newline characters and surrounding whitespace

### DIFF
--- a/sorting/datetime-moment.js
+++ b/sorting/datetime-moment.js
@@ -33,10 +33,16 @@ $.fn.dataTable.moment = function ( format, locale ) {
 
 	// Add type detection
 	types.detect.unshift( function ( d ) {
-		// Strip HTML tags if possible
-		if ( d && d.replace ) {
-			d = d.replace(/<.*?>/g, '');
-		}
+		if ( d ) {
+			// Strip HTML tags and newline characters if possible
+	        if ( d.replace ) {
+	            d = d.replace(/(<.*?>)|(\r?\n|\r)/g, '');
+	        }
+			// Strip out surrounding whitespace if possible
+	        if ( d.trim ) {
+	            d = d.trim();
+	        }
+	    }
 
 		// Null and empty values are acceptable
 		if ( d === '' || d === null ) {
@@ -50,9 +56,17 @@ $.fn.dataTable.moment = function ( format, locale ) {
 
 	// Add sorting method - use an integer for the sorting
 	types.order[ 'moment-'+format+'-pre' ] = function ( d ) {
-		if ( d && d.replace ) {
-			d = d.replace(/<.*?>/g, '');
-		}
+		if ( d ) {
+	        // Strip HTML tags and newline characters if possible
+	        if ( d.replace ) {
+	            d = d.replace(/(<.*?>)|(\r?\n|\r)/g, '');
+	        }
+			// Strip out surrounding whitespace if possible
+	        if ( d.trim ) {
+	            d = d.trim();
+	        }
+	    }
+		
 		return d === '' || d === null ?
 			-Infinity :
 			parseInt( moment( d, format, locale, true ).format( 'x' ), 10 );


### PR DESCRIPTION
**This fixes the following issue with the momentjs date sorter:**
If the html inserted to a td is not all on one line, such as:
```html
<td ng-repeat="foo in bar"><span ng-bind="date"></span></td>
```
and instead is like:

```html
<td ng-repeat="foo in bar">
   <span ng-bind="date"></span>
</td>
```

The string checked for being a valid date ends with a newline character followed by a space, which fails to validate, causing the column to not sort.