### PR TITLE
Fix fnSetFilteringDelay when filtering disabled

### DIFF
--- a/api/fnSetFilteringDelay.js
+++ b/api/fnSetFilteringDelay.js
@@ -29,25 +29,28 @@ jQuery.fn.dataTableExt.oApi.fnSetFilteringDelay = function ( oSettings, iDelay )
 	}
 
 	this.each( function ( i ) {
-		$.fn.dataTableExt.iApiIndex = i;
-		var
-			oTimerId = null,
-			sPreviousSearch = null,
-			anControl = $( 'input', _that.fnSettings().aanFeatures.f );
-
-		anControl.unbind( 'keyup search input' ).bind( 'keyup search input', function() {
-
-			if (sPreviousSearch === null || sPreviousSearch != anControl.val()) {
-				window.clearTimeout(oTimerId);
-				sPreviousSearch = anControl.val();
-				oTimerId = window.setTimeout(function() {
-					$.fn.dataTableExt.iApiIndex = i;
-					_that.fnFilter( anControl.val() );
-				}, iDelay);
-			}
-		});
-
-		return this;
+        	if ( typeof _that.fnSettings().aanFeatures.f !== 'undefined' )
+        	{
+			$.fn.dataTableExt.iApiIndex = i;
+			var
+				oTimerId = null,
+				sPreviousSearch = null,
+				anControl = $( 'input', _that.fnSettings().aanFeatures.f );
+	
+			anControl.unbind( 'keyup search input' ).bind( 'keyup search input', function() {
+	
+				if (sPreviousSearch === null || sPreviousSearch != anControl.val()) {
+					window.clearTimeout(oTimerId);
+					sPreviousSearch = anControl.val();
+					oTimerId = window.setTimeout(function() {
+						$.fn.dataTableExt.iApiIndex = i;
+						_that.fnFilter( anControl.val() );
+					}, iDelay);
+				}
+			});
+	
+			return this;
+        	}
 	} );
 	return this;
 };


### PR DESCRIPTION
Adds a check to fnSetFilteringDelay() that the table actually has the search box enabled - previously calling fnSetFilteringDelay() for a table having filtering disabled would hijack ALL the search input box 'keyup' bindings on the whole page, meaning that the only search box that would work properly would be the last table added (which didn't have search enabled).