### PR TITLE
Firefox is not sorting correctly when format contains spaces or colons

### DIFF
--- a/sorting/datetime-moment.js
+++ b/sorting/datetime-moment.js
@@ -54,7 +54,8 @@ $.fn.dataTable.moment = function ( format, locale ) {
 	} );
 
 	// Add sorting method - use an integer for the sorting
-	types.order[ 'moment-'+format+'-pre' ] = function ( d ) {
+	var formatKey = format.replace(/[^a-zA-Z0-9-]/g, '-');
+	types.order[ 'moment-'+formatKey+'-pre' ] = function ( d ) {
 		if ( d ) {
 			// Strip HTML tags and newline characters if possible
 			if ( d.replace ) {


### PR DESCRIPTION
When format is something alike `DD-MM-YYYY HH:mm` I can't sort correctly. Sorting seems to happens on as if it is a number (01-01 ... 01-02 ... 02-01) instead of as a date.

This happens in Firefox. At least Chrome doesn't seem to be affected.