### PR TITLE
Update Galician translation

### DIFF
--- a/i18n/Galician.lang
+++ b/i18n/Galician.lang
@@ -3,6 +3,7 @@
  *  @name Galician
  *  @anchor Galician
  *  @author <i>Emilio</i>
+ *  @author <i>Xosé Antonio Rubal López</i>
  */
 
 {
@@ -10,8 +11,8 @@
 	"sLengthMenu":     "Mostrar _MENU_ rexistros",
 	"sZeroRecords":    "Non se atoparon resultados",
 	"sEmptyTable":     "Ningún dato dispoñible nesta táboa",
-	"sInfo":           "Mostrando rexistros do _START_ ó _END_ dun total de _TOTAL_ rexistros",
-	"sInfoEmpty":      "Mostrando rexistros do 0 ó 0 dun total de 0 rexistros",
+	"sInfo":           "Mostrando rexistros do _START_ ao _END_ dun total de _TOTAL_ rexistros",
+	"sInfoEmpty":      "Mostrando rexistros do 0 ao 0 dun total de 0 rexistros",
 	"sInfoFiltered":   "(filtrado dun total de _MAX_ rexistros)",
 	"sInfoPostFix":    "",
 	"sSearch":         "Buscar:",
@@ -25,7 +26,7 @@
 		"sPrevious": "Anterior"
 	},
 	"oAria": {
-		"sSortAscending":  ": Activar para ordear a columna de maneira ascendente",
-		"sSortDescending": ": Activar para ordear a columna de maneira descendente"
+		"sSortAscending":  ": Activar para ordenar a columna de maneira ascendente",
+		"sSortDescending": ": Activar para ordenar a columna de maneira descendente"
 	}
 }


### PR DESCRIPTION
Update translation to [last Galician standard](https://gl.wikipedia.org/wiki/Normativa_oficial_do_galego).