### PR TITLE
Add support for dataTables.defaults in conditionalPaging plugin

### DIFF
--- a/features/conditionalPaging/dataTables.conditionalPaging.js
+++ b/features/conditionalPaging/dataTables.conditionalPaging.js
@@ -32,7 +32,7 @@
             return;
         }
 
-        var options = dtSettings.oInit.conditionalPaging;
+        var options = dtSettings.oInit.conditionalPaging || $.fn.dataTable.defaults.conditionalPaging;
 
         if ($.isPlainObject(options) || options === true) {
             var config = $.isPlainObject(options) ? options : {},


### PR DESCRIPTION
Hey there,

this fix is to allow global configuration for the `conditionalPaging` plugin. If the application has a lot of tables, it's more convenient to supply conditionalPaging option globally.