### PR TITLE
ColumnSearch feature

### DIFF
--- a/features/columnsearch
+++ b/features/columnsearch
@@ -10,14 +10,44 @@
  */
 
 /**
- * Example usage
+ * Example usage 1
  * @example
+ * zero configuration - displays a select in the footer of each column
  * var table = $('#table_id').DataTable();
- * columnSearch =
- *     new $.fn.dataTable.ColumnSearch(table, {
- *         searchElementType: 'select',
- *         rowId: 'rowSearch'
- *     });
+ * $.fn.dataTable.ColumnSearch(table);
+ */
+/**
+ * Example usage 2
+ * @example
+ * select search targetting specific columns
+ * var table = $('#table_id').DataTable();
+ * $.fn.dataTable.ColumnSearch(table, {
+ *      selectAllText: 'Any',
+ *      cols: [0,3,5]
+ * }); 
+ */
+/**
+ * Example usage 3
+ * @example
+ * text search with headings as placeholder
+ * var table = $('#table_id').DataTable();
+ * $.fn.dataTable.ColumnSearch(table, {
+ *      searchElementType: 'text',
+ *      displayHeadingAsPlaceholder: true
+ * }); 
+ */
+/**
+ * Example usage 4
+ * @example
+ * text search targetting the header or 
+ * footer row specified by rowId, and
+ * targetting specific columns
+ * var table = $('#table_id').DataTable();
+ * $.fn.dataTable.ColumnSearch(table, {
+ *      searchElementType: 'Any',
+ *      rowId: 'rowSearch',
+ *      cols: [0,3,5]
+ * }); 
  */
 (function ($) {
     var ColumnSearch = function (dt, options) {
@@ -27,16 +57,20 @@
         else initTextSearch();
 
         function initSelectSearch() {
-            if (opts.rowId != null) {
+            if (opts.rowId !== null) {
                 $('tr#' + opts.rowId + ' th', dt.table().node()).each(function(i) {
-                    var column = dt.column(i);
-                    appendSelectTo($(this), column);
+                    if (opts.cols.indexOf(i) !== -1) {
+                        var column = dt.column(i);
+                        appendSelectTo($(this), column);
+                    }
                 });
             }
             else {
-                dt.columns().every( function () {
-                    var column = this;
-                    appendSelectTo($(column.footer()).empty(), column);
+                dt.columns().every( function (i) {
+                    if (opts.cols.indexOf(i) !== -1) {
+                        var column = this;
+                        appendSelectTo($(column.footer()).empty(), column);
+                    }
                 } );
             }            
         }
@@ -60,20 +94,24 @@
         }
 
         function initTextSearch() {
-             if (opts.rowId != null) {
+             if (opts.rowId !== null) {
                 $('tr#' + opts.rowId + ' th', dt.table().node()).each(function(i) {
-                    var column = dt.column(i);
-                    var header = $(column.header());
-                    var headerText = header.text();
-                    appendTextInputTo($(this), column, opts.displayHeadingAsPlaceholder ? headerText : '');
+                    if (opts.cols.indexOf(i) !== -1) {
+                        var column = dt.column(i);                    
+                        var header = $(column.header());
+                        var headerText = header.text();
+                        appendTextInputTo($(this), column, opts.displayHeadingAsPlaceholder ? headerText : '');
+                    }
                 });
             }
             else {
-                dt.columns().every( function () {
-                    var column = this;
-                    var footer = $(column.footer());
-                    var footerText = footer.text();
-                    appendTextInputTo(footer.empty(), column, opts.displayHeadingAsPlaceholder ? footerText : '');
+                dt.columns().every( function (i) {
+                    if (opts.cols.indexOf(i) !== -1) {
+                        var column = this;
+                        var footer = $(column.footer());
+                        var footerText = footer.text();
+                        appendTextInputTo(footer.empty(), column, opts.displayHeadingAsPlaceholder ? footerText : '');
+                    }
                 } );
             }            
         }
@@ -94,7 +132,9 @@
     ColumnSearch.defaults = {
         searchElementType: 'select',
         selectAllText: 'All',
-        displayHeadingAsPlaceholder: false
+        displayHeadingAsPlaceholder: false,
+        rowId: null,
+        cols: []
     };
 
     $.fn.dataTable.ColumnSearch = ColumnSearch;

--- a/features/columnsearch
+++ b/features/columnsearch
@@ -59,7 +59,7 @@
         function initSelectSearch() {
             if (opts.rowId !== null) {
                 $('tr#' + opts.rowId + ' th', dt.table().node()).each(function(i) {
-                    if (opts.cols.indexOf(i) !== -1) {
+                    if (opts.cols.length === 0 || opts.cols.indexOf(i) !== -1) {
                         var column = dt.column(i);
                         appendSelectTo($(this), column);
                     }
@@ -67,7 +67,7 @@
             }
             else {
                 dt.columns().every( function (i) {
-                    if (opts.cols.indexOf(i) !== -1) {
+                    if (opts.cols.length === 0 || opts.cols.indexOf(i) !== -1) {
                         var column = this;
                         appendSelectTo($(column.footer()).empty(), column);
                     }
@@ -96,7 +96,7 @@
         function initTextSearch() {
              if (opts.rowId !== null) {
                 $('tr#' + opts.rowId + ' th', dt.table().node()).each(function(i) {
-                    if (opts.cols.indexOf(i) !== -1) {
+                    if (opts.cols.length === 0 || opts.cols.indexOf(i) !== -1) {
                         var column = dt.column(i);                    
                         var header = $(column.header());
                         var headerText = header.text();
@@ -106,7 +106,7 @@
             }
             else {
                 dt.columns().every( function (i) {
-                    if (opts.cols.indexOf(i) !== -1) {
+                    if (opts.cols.length === 0 || opts.cols.indexOf(i) !== -1) {
                         var column = this;
                         var footer = $(column.footer());
                         var footerText = footer.text();

--- a/features/columnsearch
+++ b/features/columnsearch
@@ -1,0 +1,102 @@
+/**
+ * @summary     ColumnSearch
+ * @description Feature to provide column searching by text input or select
+ * @version     1.0.0
+ * @file        columnsearch.js
+ * @author      datahandler (www.datahandler.uk)
+ * @copyright   Copyright datahandler (www.datahandler.uk)
+ * 
+ * License      MIT - http://datatables.net/license/mit
+ */
+
+/**
+ * Example usage
+ * @example
+ * var table = $('#table_id').DataTable();
+ * columnSearch =
+ *     new $.fn.dataTable.ColumnSearch(table, {
+ *         searchElementType: 'select',
+ *         rowId: 'rowSearch'
+ *     });
+ */
+(function ($) {
+    var ColumnSearch = function (dt, options) {
+        var opts = $.extend({}, ColumnSearch.defaults, options);
+
+        if (opts.searchElementType === 'select') initSelectSearch();
+        else initTextSearch();
+
+        function initSelectSearch() {
+            if (opts.rowId != null) {
+                $('tr#' + opts.rowId + ' th', dt.table().node()).each(function(i) {
+                    var column = dt.column(i);
+                    appendSelectTo($(this), column);
+                });
+            }
+            else {
+                dt.columns().every( function () {
+                    var column = this;
+                    appendSelectTo($(column.footer()).empty(), column);
+                } );
+            }            
+        }
+
+        function appendSelectTo($elem, col) {
+            var select = $('<select class="col-filter"><option value="">' + opts.selectAllText + '</option></select>')
+                .appendTo( $elem )
+                .on( 'change', function () {
+                    var val = $.fn.dataTable.util.escapeRegex(
+                        $(this).val()
+                    );
+
+                    col
+                        .search( val ? '^'+val+'$' : '', true, false )
+                        .draw();
+                } );
+
+                col.data().unique().sort().each( function ( d, j ) {
+                    select.append( '<option value="'+d+'">'+d+'</option>' )
+            } );
+        }
+
+        function initTextSearch() {
+             if (opts.rowId != null) {
+                $('tr#' + opts.rowId + ' th', dt.table().node()).each(function(i) {
+                    var column = dt.column(i);
+                    var header = $(column.header());
+                    var headerText = header.text();
+                    appendTextInputTo($(this), column, opts.displayHeadingAsPlaceholder ? headerText : '');
+                });
+            }
+            else {
+                dt.columns().every( function () {
+                    var column = this;
+                    var footer = $(column.footer());
+                    var footerText = footer.text();
+                    appendTextInputTo(footer.empty(), column, opts.displayHeadingAsPlaceholder ? footerText : '');
+                } );
+            }            
+        }
+
+        function appendTextInputTo($elem, col, placeholder) {
+            var textInput = $('<input type="text" placeholder="Search '+placeholder+'" />')
+            .appendTo( $elem )                
+            .on( 'keyup change', function () {
+                if ( col.search() !== this.value ) {
+                    col
+                        .search( this.value )
+                        .draw();
+                }
+            } );
+        }
+    };
+
+    ColumnSearch.defaults = {
+        searchElementType: 'select',
+        selectAllText: 'All',
+        displayHeadingAsPlaceholder: false
+    };
+
+    $.fn.dataTable.ColumnSearch = ColumnSearch;
+    $.fn.DataTable.ColumnSearch = ColumnSearch;    
+}(jQuery));

--- a/features/slidingChild/js/datatables-slidingchild.js
+++ b/features/slidingChild/js/datatables-slidingchild.js
@@ -55,8 +55,12 @@
             else {
                 $.ajax({
                     type: opts.ajax.requestType,
-                    url: opts.ajax.requestUrl,
-                    data: opts.ajax.requestData,
+                    url: opts.ajax.requestUrl,                    
+                    beforeSend: function(xhr, settings) {
+                        if (opts.ajax.getRequestData) {
+                            this.data = opts.ajax.getRequestData(dtRow);
+                        }
+                    },
                     contentType: opts.ajax.contentType,
                     dataType: opts.ajax.dataType,
                     success: function (response) {


### PR DESCRIPTION
Hi Allan,

I feel very ignorant as I don't know how to use github properly. I'm trying to make a pull request for one file (details below) but I seem to have included the previous file I created for sliding child!?

Anyway, I've created a wrapper around column searching (text and select) that you have given examples for on datatables.net. I have no idea if this will be useful to anyone, but it was interesting making it.

It has the following options:

searchElementType - the type of search to create: 'select' or 'text' (default : 'select')
selectAllText - The text to display as the first select option: default 'All'
displayHeadingAsPlaceholder - specifies whether to show the column heading as a placeholder for text input searching default: false
rowId - the id of the row to append the search input

regards
Nick