### PR TITLE
Adding support mixed date and string column data

### DIFF
--- a/sorting/datetime-moment.js
+++ b/sorting/datetime-moment.js
@@ -65,8 +65,8 @@ $.fn.dataTable.moment = function ( format, locale ) {
 			d = $.trim( d );
 		}
 		
-		return d === '' || d === null ?
-			-Infinity :
+		return !moment(d, format, locale, true).isValid() ?
+			Infinity :
 			parseInt( moment( d, format, locale, true ).format( 'x' ), 10 );
 	};
 };


### PR DESCRIPTION
Add correct ordreing then date column contains some another strings.
It will be usefull, when date can be null, infinity or empty. Also this is change, move strings (invalid dates) to end of ordering because it right, string date mean something informative and no have end date.
Example:
28.11.2017 
Infinitly
22.07.2017
Will be sorted to 
22.07.2017
28.11.2017
Infinitly