### PR TITLE
Added Search Placeholder

### DIFF
--- a/i18n/Portuguese.lang
+++ b/i18n/Portuguese.lang
@@ -15,6 +15,7 @@
 	"sInfoFiltered": "(filtrado de _MAX_ registos no total)",
 	"sInfoPostFix":  "",
 	"sSearch":       "Procurar:",
+        "sSearchPlaceholder": "Procurar..."
 	"sUrl":          "",
 	"oPaginate": {
 	    "sFirst":    "Primeiro",


### PR DESCRIPTION
HTML 5 introduced a placeholder attribute for input type="text" elements to provide informational text for an input control when it has no value.