### PR TITLE
ISSUE: Finnish translation is not valid [Fixed]

### DIFF
--- a/i18n/Finnish.lang
+++ b/i18n/Finnish.lang
@@ -4,6 +4,7 @@
  *  @anchor Finnish
  *  @author Seppo Äyräväinen
  *  @author Viktors Cvetkovs
+ *  @author <a href="https://ironlions.fi">Niko Granö</a>
  */
 
 {
@@ -12,6 +13,7 @@
 	"sInfoEmpty":    "Näytetään 0 - 0 (yhteensä 0)",
 	"sInfoFiltered": "(suodatettu _MAX_ tuloksen joukosta)",
 	"sInfoPostFix":  "",
+	"sInfoThousands":  ",",
 	"sLengthMenu":   "Näytä kerralla _MENU_ riviä",
 	"sLoadingRecords": "Ladataan...", 
 	"sProcessing":   "Hetkinen...",
@@ -41,7 +43,6 @@
 			"_": "%d riviä kopioitu leikepöydälle"
 		},
 		"copyTitle": "Kopioi leikepöydälle",
-		"copyKeys": "Paina <i>ctrl</i> tai <i>\u2318</i> + <i>C</i> kopioidaksesi taulukon arvot<br>järjestelmäsi leikepöydälle. <br><br>Peruuttaaksesi paina tätä viestiä tai Esc."
+		"copyKeys": "Paina <i>ctrl</i> tai <i>\u2318</i> + <i>C</i> kopioidaksesi taulukon arvot<br> leikepöydälle. <br><br>Peruuttaaksesi klikkaa tähän tai Esc."
 	}
-}
 }


### PR DESCRIPTION
Fixed some weird words.
Added `sInfoThousands`
File was not valid due one extra `}` at end of file, so I removed it.

**Finnish translation is not valid/working before this has been merged!**