### PR TITLE
IP address field is empty bug

### DIFF
--- a/sorting/ip-address.js
+++ b/sorting/ip-address.js
@@ -18,7 +18,7 @@
 
 jQuery.extend( jQuery.fn.dataTableExt.oSort, {
 	"ip-address-pre": function ( a ) {
-		if (a == null) { return 0 }
+		if (!a) { return 0 }
 		var i, item;
 		var m = a.split("."),
 			n = a.split(":"),

--- a/sorting/ip-address.js
+++ b/sorting/ip-address.js
@@ -18,6 +18,7 @@
 
 jQuery.extend( jQuery.fn.dataTableExt.oSort, {
 	"ip-address-pre": function ( a ) {
+		if (a == null) { return 0 }
 		var i, item;
 		var m = a.split("."),
 			n = a.split(":"),


### PR DESCRIPTION
I'm using this plugin, and I'm getting the exception when this field is empty (null). One checking line on the beginning solved this problem for me.
Now, when IP address is empty, 0 will be returned, then IP column sorts as expected (empty first in ascending order)