### PR TITLE
Added translation for row selection

### DIFF
--- a/i18n/French.lang
+++ b/i18n/French.lang
@@ -25,5 +25,12 @@
 	"oAria": {
 		"sSortAscending":  ": activer pour trier la colonne par ordre croissant",
 		"sSortDescending": ": activer pour trier la colonne par ordre d&eacute;croissant"
+	},
+	"select": {
+        	"rows": {
+         		_: "%d lignes séléctionnées",
+         		0: "Aucune ligne séléctionnée",
+        		1: "1 ligne séléctionnée"
+        	}  
 	}
 }


### PR DESCRIPTION
Added missing translation for row selection.
https://datatables.net/forums/discussion/35398/i18n-translation-for-n-rows-selected