### PR TITLE
Fix broken update on changing input box value

### DIFF
--- a/pagination/extjs.js
+++ b/pagination/extjs.js
@@ -86,7 +86,7 @@ $.fn.dataTableExt.oPagination.extStyle = {
   
         nPageNumBox.change(function () {
             var pageValue = parseInt($(this).val(), 10) - 1 ; // -1 because pages are 0 indexed, but the UI is 1
-            var oPaging = oSettings.oInstance.fnPagingInfo();
+            var oPaging = oSettings.oInstance.fnExtStylePagingInfo();
             
             if(pageValue === NaN || pageValue<0 ){
                 pageValue = 0;


### PR DESCRIPTION
The table would not update if you changed the page value in the input box, i.e. if the input box showed page 1 and you changed it to page 5, nothing would happen whereas you would expect page 5 to be loaded into your table.

`fnExtStylePagingInfo` is used in 3 other places in this file, so I guessed that the usage of `fnPagingInfo` in the `nPageNumBox.change` block was a typo and should have been `fnExtStylePagingInfo`. This indeed fixes the problem.