### PR TITLE
Add cyr translation

### DIFF
--- a/i18n/Serbian.lang
+++ b/i18n/Serbian.lang
@@ -1,24 +1,30 @@
 /**
- * Serbian translation (Latin alphabet)
- *  @name Serbian (Latin)
- *  @anchor Serbian (Latin)
- *  @author <a href="http://mnovakovic.byteout.com">Marko Novakovic</a>
+ * Serbian
+ *  @name Serbian
+ *  @anchor Serbian
+ *  @author <a href="http://blog.trk.in.rs">duleorlovic</a>
  */
 
 {
-    "sProcessing":   "Procesiranje u toku...",
-    "sLengthMenu":   "Prikaži _MENU_ elemenata",
-    "sZeroRecords":  "Nije pronađen nijedan rezultat",
-    "sInfo":         "Prikaz _START_ do _END_ od ukupno _TOTAL_ elemenata",
-    "sInfoEmpty":    "Prikaz 0 do 0 od ukupno 0 elemenata",
-    "sInfoFiltered": "(filtrirano od ukupno _MAX_ elemenata)",
-    "sInfoPostFix":  "",
-    "sSearch":       "Pretraga:",
-    "sUrl":          "",
-    "oPaginate": {
-        "sFirst":    "Početna",
-        "sPrevious": "Prethodna",
-        "sNext":     "Sledeća",
-        "sLast":     "Poslednja"
-    }
+	"sEmptyTable":     "Нема података у табели",
+	"sInfo":           "Приказ _START_ до _END_ од укупно _TOTAL_ записа",
+	"sInfoEmpty":      "Приказ 0 до 0 од укупно 0 записа",
+	"sInfoFiltered":   "(филтрирано од укупно _MAX_ записа)",
+	"sInfoPostFix":    "",
+	"sInfoThousands":  ".",
+	"sLengthMenu":     "Прикажи _MENU_ записа",
+	"sLoadingRecords": "Учитавање...",
+	"sProcessing":     "Обрада...",
+	"sSearch":         "Претрага:",
+	"sZeroRecords":    "Нису пронађени одговарајући записи",
+	"oPaginate": {
+		"sFirst":    "Почетна",
+		"sLast":     "Последња",
+		"sNext":     "Следећа",
+		"sPrevious": "Предходна"
+	},
+	"oAria": {
+		"sSortAscending":  ": активирајте да сортирате колону узлазно",
+		"sSortDescending": ": активирајте да сортирате колону силазно"
+	}
 }

--- a/i18n/Serbian_latin.lang
+++ b/i18n/Serbian_latin.lang
@@ -1,0 +1,30 @@
+/**
+ * Serbian translation (Latin alphabet)
+ *  @name Serbian (Latin)
+ *  @anchor Serbian (Latin)
+ *  @author <a href="http://mnovakovic.byteout.com">Marko Novakovic</a>
+ */
+
+{
+	"sEmptyTable":     "Nema podataka u tabeli",
+	"sInfo":           "Prikaz _START_ do _END_ od ukupno _TOTAL_ zapisa",
+	"sInfoEmpty":      "Prikaz 0 do 0 od ukupno 0 zapisa",
+	"sInfoFiltered":   "(filtrirano od ukupno _MAX_ zapisa)",
+	"sInfoPostFix":    "",
+	"sInfoThousands":  ".",
+	"sLengthMenu":     "Prikaži _MENU_ zapisa",
+	"sLoadingRecords": "Učitavanje...",
+	"sProcessing":     "Obrada...",
+	"sSearch":         "Pretraga:",
+	"sZeroRecords":    "Nisu pronađeni odgovarajući zapisi",
+	"oPaginate": {
+		"sFirst":    "Početna",
+		"sLast":     "Poslednja",
+		"sNext":     "Sledeća",
+		"sPrevious": "Predhodna"
+	},
+	"oAria": {
+		"sSortAscending":  ": aktivirajte da sortirate kolonu uzlazno",
+		"sSortDescending": ": aktivirajte da sortirate kolonu silazno"
+	}
+}


### PR DESCRIPTION
I added Cyrillic translation and renamed Serbian.lang to Serbian_latin.lang, since Cyrillic is default alphabet in Serbia. Look for example [in rails](https://github.com/svenfuchs/rails-i18n/blob/master/rails/locale/sr.yml)