### PR TITLE
French localization for the thousands separator

### DIFF
--- a/i18n/French.lang
+++ b/i18n/French.lang
@@ -11,7 +11,7 @@
 	"sInfoEmpty":      "Affichage de l'élément 0 à 0 sur 0 élément",
 	"sInfoFiltered":   "(filtré à partir de _MAX_ éléments au total)",
 	"sInfoPostFix":    "",
-	"sInfoThousands":  ",",
+	"sInfoThousands":  " ",
 	"sLengthMenu":     "Afficher _MENU_ éléments",
 	"sLoadingRecords": "Chargement...",
 	"sProcessing":     "Traitement...",


### PR DESCRIPTION
Changed the comma to a thin space character in the "sInfoThousands" key.