### PR TITLE
Added hysteresis to length, clickable "…more"

### DIFF
--- a/dataRender/ellipsis.js
+++ b/dataRender/ellipsis.js
@@ -48,42 +48,56 @@
  */
 
 jQuery.fn.dataTable.render.ellipsis = function ( cutoff, wordbreak, escapeHtml ) {
-	var esc = function ( t ) {
-		return t
-			.replace( /&/g, '&amp;' )
-			.replace( /</g, '&lt;' )
-			.replace( />/g, '&gt;' )
-			.replace( /"/g, '&quot;' );
-	};
-
-	return function ( d, type, row ) {
-		// Order, search and type get the original data
-		if ( type !== 'display' ) {
-			return d;
-		}
-
-		if ( typeof d !== 'number' && typeof d !== 'string' ) {
-			return d;
-		}
-
-		d = d.toString(); // cast numbers
-
-		if ( d.length <= cutoff ) {
-			return d;
-		}
-
-		var shortened = d.substr(0, cutoff-1);
-
-		// Find the last white space character in the string
-		if ( wordbreak ) {
-			shortened = shortened.replace(/\s([^\s]*)$/, '');
-		}
-
-		// Protect against uncontrolled HTML input
-		if ( escapeHtml ) {
-			shortened = esc( shortened );
-		}
-
-		return '<span class="ellipsis" title="'+esc(d)+'">'+shortened+'&#8230;</span>';
-	};
+    var esc = function ( t ) {
+        return t
+            .replace( /&/g, '&amp;' )
+            .replace( /</g, '&lt;' )
+            .replace( />/g, '&gt;' )
+            .replace( /"/g, '&quot;' );
+    };
+ 
+    return function ( d, type, row ) {
+        // Order, search and type get the original data
+        if ( type !== 'display' ) {
+            return d;
+        }
+ 
+        if ( typeof d !== 'number' && typeof d !== 'string' ) {
+            return d;
+        }
+ 
+        d = d.toString(); // cast numbers
+ 
+        if ( d.length <= cutoff * 1.5) {
+            return d;
+        }
+ 
+        var shortened = d.substr(0, cutoff-1);
+ 
+        // Find the last white space character in the string
+        if ( wordbreak ) {
+            shortened = shortened.replace(/\s([^\s]*)$/, '');
+        }
+ 
+        // Protect against uncontrolled HTML input
+        if ( escapeHtml ) {
+            shortened = esc( shortened );
+        }
+        var myID = row[0];
+        return '<span class="ellipsis" title="'+esc(d)+'">'+ shortened + '</span><a id="ellipsis_' + myID + '" onclick=toggleVisibility(' + myID + ') class="ellipsis" style="font-style: italic"> &#8230more</a><span id="truncatedItem_' + myID + '" style="display:none">' +d.substr(shortened.length, d.length)+'<span>';
+    };
 };
+
+
+function toggleVisibility(myId){
+	var truncatedText = document.getElementById("truncatedItem_"+myId);
+	var ellipsis = document.getElementById("ellipsis_" + myId);
+	if(ellipsis.innerText === truncatedText.innerText) {
+        ellipsis.innerText = " …more";
+        ellipsis.style = "font-style: italic";
+  	}
+	else {
+		ellipsis.innerText = truncatedText.innerText;
+        ellipsis.style  = "";
+	}
+} 


### PR DESCRIPTION
I added some hysteresis to the cutoff length to avoid the situation where a block of text that is one word longer than the cutoff gets truncated. By making the cutoff say, 1.5 times the length of the final text you can only truncate text that is significantly longer than the cutoff. So if your length is 60 you'll end up with text from 60-90 chars in length, and any that are over 90 get truncated to 60. This gives a much more pleasing result.

Example, using the three sentence below:
**source**

> Let's say the length was 30 chars.
> the previous sentence would lose just last word because it is 31 chars long.
> This one wouldn't.
> 

**default way**

> Let's say the length was 30…
> the previous sentence would be…
> This one wouldn't.
>

**my way**
> Let's say the length was 30 chars.
> the previous sentence would be…
> This one wouldn't.
>

Also I added a clickable …more tag at the truncation point, that toggles the visibility of the truncated text. This is a bit^h^h^h^h totally kludgy, I'm not a web designer, but it works for my use.