### PR TITLE
Localize pagination input plugin page label

### DIFF
--- a/pagination/input.js
+++ b/pagination/input.js
@@ -94,7 +94,7 @@
 			}
 
 			nInput.type = 'text';
-			nPage.innerHTML = 'Page ';
+			nPage.innerHTML = language.page || '';
 
 			nPaging.appendChild(nFirst);
 			nPaging.appendChild(nPrevious);


### PR DESCRIPTION
I used the plugin to enter the page number in the pagination and found that the 'Page ' label is a hardcode. We need the ability to localize this label and omit it by default so as not to confuse non-English users.