### PR TITLE
ellipsis handle hyperlinks

### DIFF
--- a/dataRender/ellipsis.js
+++ b/dataRender/ellipsis.js
@@ -72,6 +72,13 @@ jQuery.fn.dataTable.render.ellipsis = function ( cutoff, wordbreak, escapeHtml )
 			return d;
 		}
 
+		var outerTag = false
+		if (d.includes("href")) {
+			var wrapper = $(d).clone().empty().prop('outerHTML'); 
+			d = jQuery(d).text();
+			outerTag = true			
+		}
+
 		var shortened = d.substr(0, cutoff-1);
 
 		// Find the last white space character in the string
@@ -84,6 +91,10 @@ jQuery.fn.dataTable.render.ellipsis = function ( cutoff, wordbreak, escapeHtml )
 			shortened = esc( shortened );
 		}
 
-		return '<span class="ellipsis" title="'+esc(d)+'">'+shortened+'&#8230;</span>';
+		if (outerTag) {
+			return $(wrapper).html('<span class="ellipsis" title="'+esc(d)+'">'+shortened+'&#8230;</span>')[0].outerHTML
+		} else {
+			return '<span class="ellipsis" title="'+esc(d)+'">'+shortened+'&#8230;</span>';
+		}		
 	};
 };


### PR DESCRIPTION
I found that there were issues (in my case no content visible within cell) when using the ellipsis renderer for cells with long text and also having hyperlinks: e.g. 
```<td><a href="www.google.com">Link to GOOGLE</a></td>```

I figured out that this was because the ellipsis was being applied to `<a href="www.google.com">Link to GOOGLE</a>` and not `Link to GOOGLE`, as is required. I therefore updated the script to handle the same, i.e. to extract the outer tag, have the shortening on its contents, and then reapply the previously extracted outer tag. The implementation provided here works for me.

(I am a noob with JS, so the implementation might not be great.)