### PR TITLE
Fixed issue - Datatable is displaying old value when user clicks next…

### DIFF
--- a/pagination/simple_incremental_bootstrap.js
+++ b/pagination/simple_incremental_bootstrap.js
@@ -85,6 +85,12 @@ $.fn.dataTableExt.oPagination.simple_incremental_bootstrap = {
         });
 
         $(nNext).click(function () {
+            if(oSettings.aiDisplay.length < oSettings._iDisplayLength){
+                oSettings._iRecordsTotal = oSettings._iDisplayStart + oSettings.aiDisplay.length;
+            }else{
+                oSettings._iRecordsTotal = oSettings._iDisplayStart +  oSettings._iDisplayLength + 1;
+            }
+
             if (!(oSettings.fnDisplayEnd() == oSettings.fnRecordsDisplay()
                 ||
                 oSettings.aiDisplay.length < oSettings._iDisplayLength)) {


### PR DESCRIPTION
Startindex was always zero even after clicking on any page number.This PR has fix for that.
Please have a look and let me know if any changes required