### PR TITLE
Fix: turkish-string sort plugin example

### DIFF
--- a/sorting/turkish-string.js
+++ b/sorting/turkish-string.js
@@ -11,7 +11,7 @@
  *    // Use plug-in for all columns
  *    $('#example').dataTable({
  *       columnDefs: [
- *           { type: 'turkish'. targets: '_all' }
+ *           { type: 'turkish', targets: '_all' }
  *       ]
  *   });
  */


### PR DESCRIPTION
I corrected the typo in the sample code.