### PR TITLE
Update filter on return plugin

### DIFF
--- a/api/filterOnReturn().js
+++ b/api/filterOnReturn().js
@@ -1,0 +1,36 @@
+/**
+ * This plug-in removes the default behaviour of DataTables to filter on each
+ * keypress, and replaces with it the requirement to press the enter key to
+ * perform the filter.
+ *
+ *  @name filterOnReturn
+ *  @summary Require the return key to be pressed to filter a table
+ *  @author [Brian Matovu](http://www.bmatovu.com)
+ *
+ *  @returns {jQuery} jQuery instance
+ *
+ *  @example
+ *    $(document).ready(function() {
+ *        var users_dt = $('table[id=tbl_users]').dataTable();
+ *        
+ *        users_dt.filterOnReturn();
+ *    });
+ */
+
+jQuery.fn.dataTable.Api.register('filterOnReturn()', function() {
+    var dt = this;
+
+    dt.settings().each(function (setting) {
+        $.each(setting.aanFeatures.f, function(idx, filter) {
+            var dtFilterInput = $('input', filter);
+            
+            dtFilterInput.unbind();
+
+            dtFilterInput.bind('keyup', function (event) {
+                if (event.keyCode == 13) {
+                    dt.search(this.value).draw();
+                }
+            });
+        });
+    });
+});


### PR DESCRIPTION
**Fixes legacy API method `fnFilterOnReturn`** #354

[Uncaught TypeError: $datatable.DataTable(...).fnFilterOnReturn is not a function](https://datatables.net/forums/discussion/comment/140011/#Comment_140011)