### PR TITLE
The Mongolian translations of sNext and sPrevious button

### DIFF
--- a/i18n/Mongolian.lang
+++ b/i18n/Mongolian.lang
@@ -20,8 +20,8 @@
         "oPaginate": {
         	"sFirst":    "Эхнийх",
                 "sLast":     "Сүүлийнх",
-                "sNext":     "Өмнөх",
-                "sPrevious": "Дараах"
+                "sNext":     "Дараах",
+                "sPrevious": "Өмнөх"
         },
         "oAria": {
                 "sSortAscending":  ": цагаан толгойн дарааллаар эрэмбэлэх",


### PR DESCRIPTION
The Mongolian translations of sNext and sPrevious were interchanged so I have swapped the translations to become right.