### PR TITLE
Update Portuguese.lang

### DIFF
--- a/i18n/Portuguese.lang
+++ b/i18n/Portuguese.lang
@@ -6,14 +6,14 @@
  */
 
 {
-	"sEmptyTable":   "Não foi encontrado nenhum registro",
+	"sEmptyTable":   "Não foi encontrado nenhum registo",
 	"sLoadingRecords": "A carregar...",
 	"sProcessing":   "A processar...",
-	"sLengthMenu":   "Mostrar _MENU_ registros",
+	"sLengthMenu":   "Mostrar _MENU_ registos",
 	"sZeroRecords":  "Não foram encontrados resultados",
-	"sInfo":         "Mostrando de _START_ até _END_ de _TOTAL_ registros",
-	"sInfoEmpty":    "Mostrando de 0 até 0 de 0 registros",
-	"sInfoFiltered": "(filtrado de _MAX_ registros no total)",
+	"sInfo":         "Mostrando de _START_ até _END_ de _TOTAL_ registos",
+	"sInfoEmpty":    "Mostrando de 0 até 0 de 0 registos",
+	"sInfoFiltered": "(filtrado de _MAX_ registos no total)",
 	"sInfoPostFix":  "",
 	"sSearch":       "Procurar:",
 	"sUrl":          "",


### PR DESCRIPTION
Correct word in European Portuguese is "registo", not "registro" (this is the Brazilian form).