### PR TITLE
Fix: Page Length Control would vanish when switching to All

### DIFF
--- a/features/conditionalPageLength/dataTables.conditionalPageLength.js
+++ b/features/conditionalPageLength/dataTables.conditionalPageLength.js
@@ -43,7 +43,12 @@
             return;
         }
 
-        var options = dtSettings.oInit.conditionalPageLength || $.fn.dataTable.defaults.conditionalPageLength;
+        var options = dtSettings.oInit.conditionalPageLength || $.fn.dataTable.defaults.conditionalPageLength,
+            lengthMenu = dtSettings.aLengthMenu || $.fn.dataTable.defaults.lengthMenu,
+            lengthMenuValues = Array.isArray(lengthMenu[0]) ? lengthMenu[0] : lengthMenu;
+            
+        lengthMenuValues = lengthMenuValues.filter(function(n) { return n > 0 });
+        var smallestLength = Math.min.apply(Math, lengthMenuValues);
 
         if ($.isPlainObject(options) || options === true) {
             var config = $.isPlainObject(options) ? options : {},
@@ -55,7 +60,7 @@
                         size = api.rows({search:'applied'}).count();
 
                     if (e instanceof $.Event) {
-                        if (pages <= 1) {
+                        if (pages <= 1 && size <= smallestLength) {
                             if (config.style === 'fade') {
                                 $paging.stop().fadeTo(speed, 0);
                             }
@@ -72,7 +77,7 @@
                             }
                         }
                     }
-                    else if (pages <= 1) {
+                    else if (pages <= 1 && size <= smallestLength) {
                         if (config.style === 'fade') {
                             $paging.css('opacity', 0);
                         }


### PR DESCRIPTION
Fix an issue where the Page Length Control would vanish when switching to 'All' (-1) as the option. Update now only makes the control vanish if the page size is smaller than the smallest length setting and we're only viewing a single or 0 pages.