### PR TITLE
Bugfix in i18n German

### DIFF
--- a/i18n/German.lang
+++ b/i18n/German.lang
@@ -1,13 +1,3 @@
-/**
- * German translation
- *  @name German
- *  @anchor German
- *  @author Joerg Holz
- *  @author DJmRek - Markus Bergt
- *  @author OSWorX https://osworx.net
- *  @lcid de_de
- */
-
 {
 	"sEmptyTable":   	"Keine Daten in der Tabelle vorhanden",
 	"sInfo":         	"_START_ bis _END_ von _TOTAL_ Einträgen",


### PR DESCRIPTION
The language file cannot be included when adding a comment at the beginning. Problem should be solved for all languages though.

I know you asked to make use of the management system but on https://datatables.net/plug-ins/i18n/German.html the comments are not shown.