### PR TITLE
Fix IP address sorting when there are empty entries in the table

### DIFF
--- a/sorting/ip-address.js
+++ b/sorting/ip-address.js
@@ -25,7 +25,7 @@ jQuery.extend( jQuery.fn.dataTableExt.oSort, {
 		var x, xa;
 
 		if (!a) {
-			return 0
+			return '000000000000';
 		}
 
 		a = a.replace(/<[\s\S]*?>/g, "");


### PR DESCRIPTION
When a table contains empty values, sorting by IP addresses using the `ip-address.js` sorting plugin
caused erratic sorting behaviour. The empty lines are not sorted correctly and remain scattered about
the rest of the rows.

This seems to be due to a type issue: The ip-address sorting plugin has a guard-clause if-statement
that checks if the value that is to be sorted is false-y. In that case, the integer `0` is returned.
The function seems to usually normalise ip addresses to a lexicographically sortable format, and
values like `"86b4b93fbbf0418144b55bc45057b720"` and `"173040030054"` are returned.

The resulting comparison between strings and integers seems to cause misplaced empty rows and all-over
weird sorting behaviour.

This commit changes the value returned by the guard-clause to the string value `"000000000000"`, which
is simliar to the normalized IPv4 format already used by the plugin.

I used the following Table for replicating and testing this behaviour:

```html
<table id="example">
    <thead>
    <tr><th>IP Address</th></tr>
    </thead>
    <tbody>
    <tr><td>86b4:b93f:bbf0:4181:44b5:5bc4:5057:b720</td></tr>
    <tr><td>77c9:c90d:1a61:71d6:5934:6d7f:8c84:8c10</td></tr>
    <tr><td>dee9:7842:9465:e611:8367:158d:c1f0:7c3a</td></tr>
    <tr><td>1de5:6f95:dd0b:b4af:7443:1d43:4ce1:c717</td></tr>
    <tr><td></td></tr>
    <tr><td>379f:d5cf:846:f00a:24eb:8c89:632b:2709</td></tr>
    <tr><td>3819:fb76:e3c8:d285:5110:e3bb:f6be:f265</td></tr>
    <tr><td>536a:cfc9:2bd6:6efa:68e8:c5b7:7ffe:bfb3</td></tr>
    <tr><td>7a47:5d01:859d:af52:7d5:1f0d:f91c:67a0</td></tr>
    <tr><td>116c:9989:976d:e853:4544:23f4:be60:6712</td></tr>
    <tr><td></td></tr>
    <tr><td>6897:6776:f363:375b:3316:b274:4e5b:c79d</td></tr>
    <tr><td>1de7:9ee1:4d76:514e:b188:bcde:dfb4:1d43</td></tr>
    <tr><td>5d6a:986a:ab23:d2a6:6a9c:376c:b210:a482</td></tr>
    <tr><td>154.161.39.11</td></tr>
    <tr><td>173.40.30.54</td></tr>
    <tr><td>240.240.128.62:80</td></tr>
    <tr><td>234.14.118.69</td></tr>
    <tr><td></td></tr>
    <tr><td>169.174.175.188</td></tr>
    <tr><td>184.17.189.21</td></tr>
    <tr><td>183.235.248.125</td></tr>
    <tr><td>119.108.28.112</td></tr>
    <tr><td></td></tr>
    <tr><td>124.229.148.191</td></tr>
    <tr><td>69.25.65.165</td></tr>
    <tr><td>246.93.224.233</td></tr>
    <tr><td></td></tr>
    </tbody>
</table>
```

```javascript
$('#example').dataTable({
    columnDefs: [{type: 'ip-address', targets: 0}]
});
```