### PR TITLE
Remove resize helper object on table destruction

### DIFF
--- a/features/pageResize/dataTables.pageResize.js
+++ b/features/pageResize/dataTables.pageResize.js
@@ -83,6 +83,12 @@ var PageResize = function ( dt, pageResizeManualDelta )
 		host.css( 'position', 'relative' );
 	}
 
+    var onDestroy = function () {
+        dt.off('.pageResize', onDestroy);
+        this.s.obj && this.s.obj.remove();
+    }.bind(this);
+    dt.on('destroy.pageResize', onDestroy);
+
 	this._attach();
 	this._size();
 };
@@ -162,8 +168,10 @@ PageResize.prototype = {
 
 		obj
 			.appendTo( this.s.host )
-			.attr( 'data', 'about:blank' );
-	}
+            .attr( 'data', 'about:blank' );
+
+        this.s.obj = obj;
+    }
 };
 
 


### PR DESCRIPTION
I am using this feature in a sample project, where pageResize is configurable through a checkbox. On change, the table is destroyed and reinitialized. The document to which the resize handler is attached, is not removed on table destruction, resulting (in my sample project) in multiple added documents and resize handlers, which in its turn results in some wonky behavior.

I am not really certain of the best way to intercept and handle the table destruction, for now i added a callback to the `aoDestroyCallback` array. You might want to see the PR as just an idea. 

I am unsure whether this is of importance in any other uses of the feature, in those cases it is probably just set on initialization.

NOTE: Minification has not taken place yet.