### PR TITLE
Fix notEnds/notStarts for searchBuilder plugin

### DIFF
--- a/i18n/ar.json
+++ b/i18n/ar.json
@@ -91,8 +91,8 @@
                 "endsWith": "تنتهي ب",
                 "equals": "تساوي",
                 "notContains": "لا تحتوي",
-                "notStarts": "لا تبدأ بـ",
-                "notEnds": "لا تنتهي بـ"
+                "notStartsWith": "لا تبدأ بـ",
+                "notEndsWith": "لا تنتهي بـ"
             },
             "array": {
                 "equals": "تساوي",

--- a/i18n/bn.json
+++ b/i18n/bn.json
@@ -187,8 +187,8 @@
                 "notEmpty": "খালি নয়",
                 "startsWith": "শুরু হয়",
                 "notContains": "বিদ্যমান নয়",
-                "notStarts": "শুরু হয় না",
-                "notEnds": "শেষ হয় না"
+                "notStartsWith": "শুরু হয় না",
+                "notEndsWith": "শেষ হয় না"
             },
             "array": {
                 "equals": "সমান",

--- a/i18n/ca.json
+++ b/i18n/ca.json
@@ -168,8 +168,8 @@
                 "not": "No",
                 "notEmpty": "No buit",
                 "startsWith": "Comença amb",
-                "notEnds": "No acaba amb",
-                "notStarts": "No comença amb",
+                "notEndsWith": "No acaba amb",
+                "notStartsWith": "No comença amb",
                 "notContains": "No inclou"
             },
             "array": {

--- a/i18n/cs.json
+++ b/i18n/cs.json
@@ -47,8 +47,8 @@
                 "notEmpty": "není prázdné",
                 "startsWith": "začíná na",
                 "notContains": "Podmínka",
-                "notStarts": "Nezačíná",
-                "notEnds": "Nekončí"
+                "notStartsWith": "Nezačíná",
+                "notEndsWith": "Nekončí"
             },
             "array": {
                 "equals": "rovno",

--- a/i18n/de-DE.json
+++ b/i18n/de-DE.json
@@ -97,8 +97,8 @@
                 "notEmpty": "Nicht leer",
                 "startsWith": "Startet mit",
                 "notContains": "enthält nicht",
-                "notStarts": "startet nicht mit",
-                "notEnds": "endet nicht mit"
+                "notStartsWith": "startet nicht mit",
+                "notEndsWith": "endet nicht mit"
             },
             "array": {
                 "equals": "ist gleich",

--- a/i18n/en-GB.json
+++ b/i18n/en-GB.json
@@ -93,8 +93,8 @@
                 "notEmpty": "Not Empty",
                 "startsWith": "Starts With",
                 "notContains": "Does Not Contain",
-                "notStarts": "Does Not Start With",
-                "notEnds": "Does Not End With"
+                "notStartsWith": "Does Not Start With",
+                "notEndsWith": "Does Not End With"
             },
             "array": {
                 "without": "Without",

--- a/i18n/es-ES.json
+++ b/i18n/es-ES.json
@@ -92,8 +92,8 @@
                 "startsWith": "Empieza con",
                 "not": "Diferente de",
                 "notContains": "No Contiene",
-                "notStarts": "No empieza con",
-                "notEnds": "No termina con"
+                "notStartsWith": "No empieza con",
+                "notEndsWith": "No termina con"
             },
             "array": {
                 "not": "Diferente de",

--- a/i18n/es-MX.json
+++ b/i18n/es-MX.json
@@ -96,8 +96,8 @@
                 "startsWith": "Inicia con",
                 "notEmpty": "No vacío",
                 "notContains": "No Contiene",
-                "notEnds": "No Termina",
-                "notStarts": "No Comienza"
+                "notEndsWith": "No Termina",
+                "notStartsWith": "No Comienza"
             },
             "array": {
                 "equals": "Igual a",

--- a/i18n/et.json
+++ b/i18n/et.json
@@ -135,8 +135,8 @@
                 "not": "Ei ole",
                 "notContains": "Ei sisalda",
                 "notEmpty": "Ei ole tühi",
-                "notEnds": "Ei lõppe",
-                "notStarts": "Ei alga",
+                "notEndsWith": "Ei lõppe",
+                "notStartsWith": "Ei alga",
                 "startsWith": "Algab"
             }
         },

--- a/i18n/fa.json
+++ b/i18n/fa.json
@@ -86,8 +86,8 @@
                 "notEmpty": "خالی نباشد",
                 "startsWith": "شروع  شود با",
                 "notContains": "نباشد حاوی",
-                "notEnds": "پایان نیابد با",
-                "notStarts": "شروع نشود با"
+                "notEndsWith": "پایان نیابد با",
+                "notStartsWith": "شروع نشود با"
             },
             "array": {
                 "equals": "برابر",

--- a/i18n/fr-FR.json
+++ b/i18n/fr-FR.json
@@ -59,8 +59,8 @@
                 "startsWith": "Commence par",
                 "equals": "Égal à",
                 "notContains": "Ne contient pas",
-                "notEnds": "Ne termine pas par",
-                "notStarts": "Ne commence pas par"
+                "notEndsWith": "Ne termine pas par",
+                "notStartsWith": "Ne commence pas par"
             },
             "array": {
                 "empty": "Vide",

--- a/i18n/he.json
+++ b/i18n/he.json
@@ -163,8 +163,8 @@
                 "notEmpty": "לא ריק",
                 "startsWith": "מתחיל ב",
                 "notContains": "לא מכיל",
-                "notEnds": "לא מסתיים ב",
-                "notStarts": "לא מתחיל ב"
+                "notEndsWith": "לא מסתיים ב",
+                "notStartsWith": "לא מתחיל ב"
             },
             "array": {
                 "equals": "שווה",

--- a/i18n/it-IT.json
+++ b/i18n/it-IT.json
@@ -91,8 +91,8 @@
                 "notEmpty": "Non Vuoto",
                 "startsWith": "Inizia Con",
                 "notContains": "Non Contiene",
-                "notStarts": "Non Inizia Con",
-                "notEnds": "Non Finisce Con"
+                "notStartsWith": "Non Inizia Con",
+                "notEndsWith": "Non Finisce Con"
             },
             "array": {
                 "equals": "Uguale A",

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -64,8 +64,8 @@
                 "notEmpty": "空白ではない",
                 "startsWith": "次の文字から始まる",
                 "notContains": "次の文字を含まない",
-                "notStarts": "次の文字で始まらない",
-                "notEnds": "次の文字で終わらない"
+                "notStartsWith": "次の文字で始まらない",
+                "notEndsWith": "次の文字で終わらない"
             }
         },
         "data": "項目",

--- a/i18n/nl-NL.json
+++ b/i18n/nl-NL.json
@@ -89,8 +89,8 @@
                 "notEmpty": "Niet leeg",
                 "startsWith": "Start met",
                 "notContains": "Zonder",
-                "notEnds": "Eindigt niet met",
-                "notStarts": "Begint niet met"
+                "notEndsWith": "Eindigt niet met",
+                "notStartsWith": "Begint niet met"
             },
             "array": {
                 "equals": "Gelijk aan",

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -106,8 +106,8 @@
                 "notEmpty": "Não Vazio",
                 "startsWith": "Começa Com",
                 "notContains": "Não contém",
-                "notStarts": "Não começa com",
-                "notEnds": "Não termina com"
+                "notStartsWith": "Não começa com",
+                "notEndsWith": "Não termina com"
             },
             "array": {
                 "contains": "Contém",

--- a/i18n/pt-PT.json
+++ b/i18n/pt-PT.json
@@ -91,8 +91,8 @@
                 "notEmpty": "Não está vazio",
                 "startsWith": "Começa em",
                 "notContains": "Não contém",
-                "notStarts": "Não começa com",
-                "notEnds": "Não termina com"
+                "notStartsWith": "Não começa com",
+                "notEndsWith": "Não termina com"
             },
             "array": {
                 "equals": "Igual",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -43,8 +43,8 @@
                 "not": "Не",
                 "notEmpty": "Не пусто",
                 "notContains": "Не содержит",
-                "notStarts": "Не начинается на",
-                "notEnds": "Не заканчивается на"
+                "notStartsWith": "Не начинается на",
+                "notEndsWith": "Не заканчивается на"
             },
             "date": {
                 "after": "После",

--- a/i18n/sr-SP.json
+++ b/i18n/sr-SP.json
@@ -123,8 +123,8 @@
                 "notEmpty": "Nije prazan",
                 "startsWith": "Počinje sa",
                 "notContains": "Ne sadrži",
-                "notStarts": "Ne počinje sa",
-                "notEnds": "Ne završava se sa"
+                "notStartsWith": "Ne počinje sa",
+                "notEndsWith": "Ne završava se sa"
             },
             "array": {
                 "equals": "Jednako",

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -105,8 +105,8 @@
                 "notEmpty": "Dolu",
                 "startsWith": "İle başlar",
                 "notContains": "İçermeyen",
-                "notStarts": "Başlamayan",
-                "notEnds": "Bitmeyen"
+                "notStartsWith": "Başlamayan",
+                "notEndsWith": "Bitmeyen"
             },
             "array": {
                 "contains": "İçerir",

--- a/i18n/vi.json
+++ b/i18n/vi.json
@@ -97,8 +97,8 @@
                 "notEmpty": "Không rỗng",
                 "startsWith": "Bắt đầu với",
                 "notContains": "Không chứa",
-                "notEnds": "Không kết thúc với",
-                "notStarts": "Không bắt đầu với"
+                "notEndsWith": "Không kết thúc với",
+                "notStartsWith": "Không bắt đầu với"
             },
             "array": {
                 "equals": "Bằng",

--- a/i18n/zh-HANT.json
+++ b/i18n/zh-HANT.json
@@ -101,8 +101,8 @@
                 "notEmpty": "不為空",
                 "startsWith": "字首為",
                 "notContains": "不含",
-                "notStarts": "開頭不是",
-                "notEnds": "結尾不是"
+                "notStartsWith": "開頭不是",
+                "notEndsWith": "結尾不是"
             }
         },
         "data": "欄位",


### PR DESCRIPTION
Fixed ``notEnds`` and ``notStarts`` i18n entries for search builder plugin.
Latest version has changed the language entries, see https://github.com/DataTables/SearchBuilder/blob/3f38ca55653ceb61a8d81b7f600caf6360d8c8eb/src/searchBuilder.ts#L169-L179.

As there are several files, do I need to use https://datatables.net/plug-ins/i18n/? Greetings