### PR TITLE
ScrollResize: remove resize helper iframe on table destruction

### DIFF
--- a/features/scrollResize/dataTables.scrollResize.js
+++ b/features/scrollResize/dataTables.scrollResize.js
@@ -83,6 +83,12 @@ var ScrollResize = function ( dt )
 		that._size();
 	} );
 
+	var onDestroy = function () {
+		dt.off('.pageResize', onDestroy);
+		this.s.obj && this.s.obj.remove();
+	}.bind(this);
+	dt.on('destroy.pageResize', onDestroy);
+
 	this._attach();
 	this._size();
 };
@@ -154,7 +160,9 @@ ScrollResize.prototype = {
 		obj
 			.appendTo( this.s.host )
 			.attr( 'data', 'about:blank' );
-	}
+
+		this.s.obj = obj;
+    }
 };
 
 


### PR DESCRIPTION
Similar to PR #542, but for the scrollResize feature: The iframe element which server as a resize helper is not removed on table destruction. Reinitializing the table adds another iframe element, resulting in handling a resize event multiple times. 