### PR TITLE
Use the set moment locale as a fallback instead of fixed 'en'

### DIFF
--- a/dataRender/datetime.js
+++ b/dataRender/datetime.js
@@ -97,12 +97,8 @@
 $.fn.dataTable.render.moment = function ( from, to, locale ) {
 	// Argument shifting
 	if ( arguments.length === 1 ) {
-		locale = 'en';
 		to = from;
 		from = 'YYYY-MM-DD';
-	}
-	else if ( arguments.length === 2 ) {
-		locale = 'en';
 	}
 
 	return function ( d, type, row ) {


### PR DESCRIPTION
Is there a reason why the datetime plugin has its own fallback value for the locale? For my requirements, it is way more convenient to use the value within the moment library (i.e. `moment.locale()` or the deprecated `moment.lang()`). This way, the fallback locale is not fixed.

Also, the documentation specifies a dependency on Moment.js 1.7+. But, when using version 1.7.0, the call `m.format(...)` actually ignores the locale that was provided. It uses the locale as set with `moment.lang(locale)`, as can be seen in [this fiddle](https://jsfiddle.net/JMolenkamp/3zaku26m/3/). So, even though the third moment object was created for the 'en' locale, it is formatted as locale 'nl', since that locale was set, using `moment.lang('nl')`. For the desired functionality, the minimum version seems to be 2.8.0 ([fiddle](https://jsfiddle.net/JMolenkamp/4nLp18uq/2/)).