### PR TITLE
ScrollResize: remove draw event handler on table destruction

### DIFF
--- a/features/scrollResize/dataTables.scrollResize.js
+++ b/features/scrollResize/dataTables.scrollResize.js
@@ -79,15 +79,14 @@ var ScrollResize = function ( dt )
 		host.css( 'position', 'relative' );
 	}
 
-	dt.on( 'draw', function () {
+	dt.on( 'draw.scrollResize', function () {
 		that._size();
 	} );
 
-	var onDestroy = function () {
-		dt.off('.pageResize', onDestroy);
+	dt.on('destroy.scrollResize', function () {
+		dt.off('.scrollResize');
 		this.s.obj && this.s.obj.remove();
-	}.bind(this);
-	dt.on('destroy.pageResize', onDestroy);
+	}.bind(this));
 
 	this._attach();
 	this._size();


### PR DESCRIPTION
Turns out that i overlooked the `draw` event handler in #545, it is not removed on table destruction. Each time, the scroll resize plugin is initialized, a new event handler is added, resulting in a multitude of event handlers, executing the same functionality.

Also, i probably copied the destroy event handler from #542, so i corrected the `pageResize` event namespace to `scrollResize`. 

NOTE: I am also seeing a lot of `stateSaveParams` event handlers, but i will take a look at that at another time.