### PR TITLE
ScrollResize: redraw header on scrollbar hiding during feature initialization

### DIFF
--- a/features/scrollResize/dataTables.scrollResize.js
+++ b/features/scrollResize/dataTables.scrollResize.js
@@ -90,6 +90,17 @@ var ScrollResize = function ( dt )
 
 	this._attach();
 	this._size();
+
+	// Redraw the header if the scrollbar was visible before feature
+	// initialization, but no longer after initialization. Otherwise,
+	// the header width would differ from the body width, because the
+	// scrollbar is no longer present.
+	var settings = dt.settings()[0];
+	var divBodyEl = settings.nScrollBody;
+	var scrollBarVis = divBodyEl.scrollHeight > divBodyEl.clientHeight;
+	if (settings.scrollBarVis && !scrollBarVis) {
+		dt.columns.adjust();
+	}
 };
 
 


### PR DESCRIPTION
Whenever the scrollbar is visible before the scrollResize feature initialization, but no longer after the call to ScrollResize._size, the header maintains a width as if the scrollbar was still present, while the body actually uses the full width. This way, the header is no longer properly aligned with the body. 

See [this](https://jsfiddle.net/JMolenkamp/nf14wtLp/12/) fiddle.

Is another/better way available to get the header redrawn?