### PR TITLE
PageResize: delay initial call to _size until table is fully initialized

### DIFF
--- a/features/pageResize/dataTables.pageResize.js
+++ b/features/pageResize/dataTables.pageResize.js
@@ -98,7 +98,15 @@ var PageResize = function ( dt, pageResizeManualDelta )
     dt.on('destroy.pageResize', onDestroy);
 
 	this._attach();
-	this._size();
+
+	// Delay the initial sizing until the table is fully initialized
+	// such that the pagination element is also added and can be taken
+	// into account.
+	var initEvent = 'init.pageResize';
+	dt.on(initEvent, function () {
+		dt.off(initEvent);
+		this._size();
+	}.bind(this));
 };
 
 


### PR DESCRIPTION
The pageResize feature does not initialize properly in Chrome when rows are already present in the DOM ([fiddle](https://jsfiddle.net/JMolenkamp/m9y7zf54/77/)).
The blue color marks the available space:

![debug-2](https://user-images.githubusercontent.com/59445808/189544873-0f382692-da01-403c-a895-5836e1835769.jpg)

The moment the plugin initializes, the pagination element is not yet added to the table. In the initial call to `PageResize._size()`, this results in a faulty value for `availableHeight`, since it cannot take the height of the pagination element into account. The screenshot below is taken while at a breakpoint before execution of `PageResize._size()`, showing no pagination.

![debug-2 1](https://user-images.githubusercontent.com/59445808/189544883-27f0b712-6930-4bba-a552-c43aacfb197c.jpg)

Firefox does not have this problem, but only because the `<object>` element issues a resize event after loading, such that another call to `PageResize._size()` is executed, which corrects the faulty height.