### PR TITLE
Escape input even when no shortening required

### DIFF
--- a/dataRender/ellipsis.js
+++ b/dataRender/ellipsis.js
@@ -63,12 +63,18 @@ jQuery.fn.dataTable.render.ellipsis = function ( cutoff, wordbreak, escapeHtml )
 		}
 
 		if ( typeof d !== 'number' && typeof d !== 'string' ) {
+			if ( escapeHtml ) {
+				return esc( d );
+			}
 			return d;
 		}
 
 		d = d.toString(); // cast numbers
 
 		if ( d.length <= cutoff ) {
+			if ( escapeHtml ) {
+				return esc( d );
+			}
 			return d;
 		}
 

--- a/dataRender/ellipsis.js
+++ b/dataRender/ellipsis.js
@@ -49,7 +49,7 @@
 
 jQuery.fn.dataTable.render.ellipsis = function ( cutoff, wordbreak, escapeHtml ) {
 	var esc = function ( t ) {
-		return t
+		return ('' + t)
 			.replace( /&/g, '&amp;' )
 			.replace( /</g, '&lt;' )
 			.replace( />/g, '&gt;' )


### PR DESCRIPTION
Fixes an XSS vulnerability in the ellipsis renderer: the escape parameter was ignored unless the input was long enough for shortening to occur.