### PR TITLE
Add data renderer "anchor"

### DIFF
--- a/dataRender/anchor.js
+++ b/dataRender/anchor.js
@@ -45,32 +45,28 @@ jQuery.fn.dataTable.render.anchor = function (
       innerText = data;
     }
 
-    if (attributes typeof 'function') {
-      var tagAttributes = attributes(data, row, meta);
-    } else {
-      var tagAttributes = attributes;
-    }
+    var attributes = attributes typeof 'function' ? attributes(data, row, meta) : attributes;
 
-    if (!tagAttributes.href) {
+    if (!attributes.href) {
       switch (type) {
         case 'mail':
-          tagAttributes.href = 'mailto:' + data;
+          attributes.href = 'mailto:' + data;
           break;
         case 'phone':
-          tagAttributes.href = 'tel:' + data.replace(/[^+\d]+/g, '');
+          attributes.href = 'tel:' + data.replace(/[^+\d]+/g, '');
           break;
         case 'link':
         case default:
           try {
-            tagAttributes.href = new URL(data);
+            attributes.href = new URL(data);
           } catch (e) {
-            tagAttributes.href = data;
+            attributes.href = data;
           }
       }
     }
 
     var anchorEl = jQuery('</a>');
-    anchorEl.attr(tagAttributes).text(innerText === null ? data : innerText);
+    anchorEl.attr(attributes).text(innerText);
 
     return anchorEl[0].outerText;
   };

--- a/dataRender/anchor.js
+++ b/dataRender/anchor.js
@@ -1,0 +1,77 @@
+/**
+ *  @name anchor
+ *  @summary Renders the column data as HTML anchor (`a` tag)
+ *  @author [Fedonyuk Anton](http://ensostudio.ru)
+ *  @requires DataTables 1.10+
+ *
+ *  @param {string} type The anchor type: 'link'(by default), 'phone' or 'email'
+ *  @param {object|function} attributes The attributes of the anchor tag or the
+ *       callback function returning the tag attributes, the callback syntax:
+ *      `function (mixed data, object|array row[, object meta]): object`
+ *  @param {string|null} innerText The inner text of the anchor tag or `null` to
+ *      set text by column `data` (by default)
+ *  @returns {string}
+ *
+ *  @example
+ *    // Display `<a href="..." target="_blank">...</a>`
+ *    $('#example').DataTable({
+ *      columnDefs: [{
+ *        targets: 1,
+ *        render: $.fn.dataTable.render.anchor()
+ *      }]
+ *    });
+ *
+ *  @example
+ *    // Display `<a href="mailto:..." class="link">...</a>`
+ *    $('#example').DataTable({
+ *      columnDefs: [{
+ *        targets: 2,
+ *        render: $.fn.dataTable.render.anchor('email', {'class': 'link'})
+ *      }]
+ *    });
+ */
+jQuery.fn.dataTable.render.anchor = function (
+  type = 'link',
+  attributes = {},
+  innerText = null
+) {
+  return function (data, type, row, meta) {
+    // restriction only for table display rendering
+    if (type !== 'display') {
+      return data;
+    }
+
+    if (innerText === null) {
+      innerText = data;
+    }
+
+    if (attributes typeof 'function') {
+      var tagAttributes = attributes(data, row, meta);
+    } else {
+      var tagAttributes = attributes;
+    }
+
+    if (!tagAttributes.href) {
+      switch (type) {
+        case 'mail':
+          tagAttributes.href = 'mailto:' + data;
+          break;
+        case 'phone':
+          tagAttributes.href = 'tel:' + data.replace(/[^+\d]+/g, '');
+          break;
+        case 'link':
+        case default:
+          try {
+            tagAttributes.href = new URL(data);
+          } catch (e) {
+            tagAttributes.href = data;
+          }
+      }
+    }
+
+    var $a = jQuery('<a></a>');
+    $a.attr(tagAttributes).text(innerText === null ? data : innerText).get(0).outerText;
+
+    return $a[0];
+  };
+};

--- a/dataRender/anchor.js
+++ b/dataRender/anchor.js
@@ -69,9 +69,9 @@ jQuery.fn.dataTable.render.anchor = function (
       }
     }
 
-    var $a = jQuery('</a>');
-    $a.attr(tagAttributes).text(innerText === null ? data : innerText);
+    var anchorEl = jQuery('</a>');
+    anchorEl.attr(tagAttributes).text(innerText === null ? data : innerText);
 
-    return $a[0].outerText;
+    return anchorEl[0].outerText;
   };
 };

--- a/dataRender/anchor.js
+++ b/dataRender/anchor.js
@@ -69,9 +69,9 @@ jQuery.fn.dataTable.render.anchor = function (
       }
     }
 
-    var $a = jQuery('<a></a>');
-    $a.attr(tagAttributes).text(innerText === null ? data : innerText).get(0).outerText;
+    var $a = jQuery('</a>');
+    $a.attr(tagAttributes).text(innerText === null ? data : innerText);
 
-    return $a[0];
+    return $a[0].outerText;
   };
 };

--- a/dataRender/anchor.js
+++ b/dataRender/anchor.js
@@ -7,7 +7,7 @@
  *  @param {string} type The anchor type: 'link'(by default), 'phone' or 'email'
  *  @param {object|function} attributes The attributes of the anchor tag or the
  *       callback function returning the tag attributes, the callback syntax:
- *      `function (mixed data, object|array row[, object meta]): object`
+ *      `function (mixed data, object|array row, object meta): object`
  *  @param {string|null} innerText The inner text of the anchor tag or `null` to
  *      set text by column `data` (by default)
  *  @returns {string}
@@ -35,7 +35,7 @@ jQuery.fn.dataTable.render.anchor = function (
   attributes = {},
   innerText = null
 ) {
-  return function (data, type, row, meta) {
+  return function (data, type, row, meta = {}) {
     // restriction only for table display rendering
     if (type !== 'display') {
       return data;

--- a/dataRender/anchor.js
+++ b/dataRender/anchor.js
@@ -45,29 +45,28 @@ jQuery.fn.dataTable.render.anchor = function (
       innerText = data;
     }
 
-    var attributes = attributes typeof 'function' ? attributes(data, row, meta) : attributes;
+    var attrs = attributes typeof 'function' ? attributes(data, row, meta) : attributes;
 
-    if (!attributes.href) {
+    if (!attrs.href) {
       switch (type) {
         case 'mail':
-          attributes.href = 'mailto:' + data;
+          attrs.href = 'mailto:' + data;
           break;
         case 'phone':
-          attributes.href = 'tel:' + data.replace(/[^+\d]+/g, '');
+          attrs.href = 'tel:' + data.replace(/[^+\d]+/g, '');
           break;
         case 'link':
         case default:
           try {
-            attributes.href = new URL(data);
+            attrs.href = new URL(data);
           } catch (e) {
-            attributes.href = data;
+            attrs.href = data;
           }
       }
     }
 
-    var anchorEl = jQuery('</a>');
-    anchorEl.attr(attributes).text(innerText);
+    var anchorEl = jQuery('<a/>');
 
-    return anchorEl[0].outerText;
+    return anchorEl.attr(attrs).text(innerText)[0].outerText;
   };
 };


### PR DESCRIPTION
"anchor" renders the column data as HTML anchor.

This renderer more flexible than [hyperLink](https://datatables.net/plug-ins/dataRender/hyperLink):
- also supports phone numbers and emails
- can set inner text by `data`
- can customize tag attributes