### PR TITLE
Make Opacity 0 for the iframe in dataTables.scrollResize.ts

### DIFF
--- a/features/scrollResize/src/dataTables.scrollResize.ts
+++ b/features/scrollResize/src/dataTables.scrollResize.ts
@@ -120,6 +120,7 @@ ScrollResize.prototype = {
 				width: '100%',
 				zIndex: -1,
 				border: 0,
+				opacity: 0
 			})
 			.attr('frameBorder', '0')
 			.attr('src', 'about:blank');

--- a/features/scrollResize/src/dataTables.scrollResize.ts
+++ b/features/scrollResize/src/dataTables.scrollResize.ts
@@ -120,7 +120,7 @@ ScrollResize.prototype = {
 				width: '100%',
 				zIndex: -1,
 				border: 0,
-				opacity: 0
+				opacity: 0,
 			})
 			.attr('frameBorder', '0')
 			.attr('src', 'about:blank');


### PR DESCRIPTION
Are you happy for it to be included and distributed under the MIT license? ✔️

Fixes Iframe becoming visible when the datatable container is dragged. Occurs in Firefox on MacOS

https://github.com/user-attachments/assets/03a90318-e3bc-4fc6-a119-4438e26ab026

