### PR TITLE
OrderNumbers allow user defined className

### DIFF
--- a/features/orderNumbers/src/dataTables.orderNumbers.ts
+++ b/features/orderNumbers/src/dataTables.orderNumbers.ts
@@ -25,11 +25,13 @@ function orderNumbers(src) {
 
 /** Remove all existing indicators */
 function remove(table) {
-	$('span.dt-order-number', table.table().header()).remove();
+	let className = (table.init().orderNumbers && table.init().orderNumbers.className) ? table.init().orderNumbers.className : 'dt-order-number';
+	$('span.' + className, table.table().header()).remove();
 }
 
 /** Draw in new indicators for the currently applied order */
 function draw(table) {
+	let className = (table.init().orderNumbers && table.init().orderNumbers.className) ? table.init().orderNumbers.className : 'dt-order-number';
 	var order = table.order();
 
 	if (order.length > 1) {
@@ -42,7 +44,7 @@ function draw(table) {
 			}
 
 			$('<span>')
-				.addClass('dt-order-number')
+				.addClass(className)
 				.text(i + 1)
 				.appendTo(cell);
 		}


### PR DESCRIPTION
Are you happy for it to be included and distributed under the MIT license? ✔️

Forum Conversation: https://datatables.net/forums/discussion/79716/ordering-sequence-plugin-assign-class

30% of my dataTables have multline headers.  So for these dataTables the user can define:
`orderNumbers: {className: 'dt-order-number-top'}`
and define css with `top: 2x;` and `right: 2x` or adjust as needed.
![image](https://github.com/user-attachments/assets/89327661-11d4-40da-836c-0567b4196243)


70% of my dataTables just have a single line header.  So for these dataTables the user can define:
`orderNumbers: true`
![image](https://github.com/user-attachments/assets/2829523e-9819-47a7-8f9a-9f5477b2cf8a)

I did not add you suggestion for completeness because I did know exact what you meant:
```
DataTable.defaults.orderNumbers = {
  className: 'dt-order-number'
};
```

I have not supplied an example yet, because I couldn't figure out how to add it in the code.