### PR TITLE
Fix max-height as the size of the table

### DIFF
--- a/features/scrollResize/dataTables.scrollResize.js
+++ b/features/scrollResize/dataTables.scrollResize.js
@@ -118,6 +118,9 @@ ScrollResize.prototype = {
         availableHeight -= offsetTop;
         availableHeight -=
             settings.container.height() - (offsetTop + scrollBody.height());
+        if (settings.table.height() < availableHeight){
+          availableHeight = settings.table.height(); 
+        }
         $('div.dt-scroll-body', t.container()).css({
             maxHeight: availableHeight,
             height: availableHeight,


### PR DESCRIPTION
If the table height is smaller than the avaliable height, the size will be the table size. For example if I filter zero records on serch field.

Are you happy for it to be included and distributed under the MIT license? ✔️/❌
