### PR TITLE
Ability to set paging button to HTML in inputPaging feature

### DIFF
--- a/features/inputPaging/src/dataTables.inputPaging.ts
+++ b/features/inputPaging/src/dataTables.inputPaging.ts
@@ -282,7 +282,7 @@ function createElement(opts, text?, fn?) {
 	else {
 		// Bottom nesting level
 		if (text) {
-			el.textContent = text;
+			el.innerHTML = text;
 		}
 	}
 


### PR DESCRIPTION
I want to change the paging buttons to HTML, but it's not possible at the moment due to using `textContent`. I've changed it to `innerHTML`. I'm not sure if some would argue that this introduces self-inflicted XSS? Is there a better way of doing it?


```js
        "language": {
            "paginate": {
                "first":    '<span class="rtl:sp-hidden"><i class="fas fa-angle-double-left"></i></span><span class="ltr:sp-hidden"><i class="fas fa-angle-double-right"></i></span>',
                "last":     '<span class="rtl:sp-hidden"><i class="fas fa-angle-double-right"></i></span><span class="ltr:sp-hidden"><i class="fas fa-angle-double-left"></i></span>',
                "next":     '<span class="rtl:sp-hidden"><i class="fas fa-angle-right"></i></span><span class="ltr:sp-hidden"><i class="fas fa-angle-left"></i></span>',
                "previous": '<span class="rtl:sp-hidden"><i class="fas fa-angle-left"></i></span><span class="ltr:sp-hidden"><i class="fas fa-angle-right"></i></span>'
            }
        }
```

Are you happy for it to be included and distributed under the MIT license? ✔️
