### PR TITLE
Use 'change' event instead of 'input' for page updates

### DIFF
--- a/features/inputPaging/src/dataTables.inputPaging.ts
+++ b/features/inputPaging/src/dataTables.inputPaging.ts
@@ -75,7 +75,7 @@ DataTable.feature.register('inputPaging', function (settings, opts) {
 	});
 
 	// On new value, redraw the table
-	input.addEventListener('input', function () {
+	input.addEventListener('change', function () {
 		if (input.value) {
 			api.page(input.value - 1).draw(false);
 		}


### PR DESCRIPTION
Sorry Allan 🙈 

Switching to the `change` event ensures the table updates only after the input is finalized, preventing unnecessary redraws during typing. This enhances performance (less server side requests etc) and user experience. This is also consistent with the old input pagination plugin https://github.com/DataTables/Plugins/blob/master/pagination/input.js#L30

**What's the difference?**

https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event:
> The input event fires when the value of an `<input>`, `<select>`, or `<textarea>` element has been changed.

https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event: 
> The change event is fired for `<input>`, `<select>`, and `<textarea>` elements when an alteration to the element's value is committed by the user. Unlike the input event, the change event is not necessarily fired for each alteration to an element's value.

Are you happy for it to be included and distributed under the MIT license? ✔️
