### PR TITLE
Fix pt-BR SearchPanes title translation to display count

### DIFF
--- a/i18n/pt-BR.js
+++ b/i18n/pt-BR.js
@@ -206,7 +206,7 @@
         "emptyPanes": "Nenhum Painel de Pesquisa",
         "loadMessage": "Carregando Painéis de Pesquisa...",
         "showMessage": "Mostrar todos",
-        "title": "Filtros Ativos"
+        "title": "Filtros Ativos - %d"
     },
     "searchPlaceholder": "",
     "select": {

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -194,7 +194,7 @@
         "emptyPanes": "Nenhum Painel de Pesquisa",
         "loadMessage": "Carregando Painéis de Pesquisa...",
         "showMessage": "Mostrar todos",
-        "title": "Filtros Ativos"
+        "title": "Filtros Ativos - %d"
     },
     "searchPlaceholder": "",
     "select": {

--- a/i18n/pt-BR.mjs
+++ b/i18n/pt-BR.mjs
@@ -194,7 +194,7 @@ export default {
         "emptyPanes": "Nenhum Painel de Pesquisa",
         "loadMessage": "Carregando Painéis de Pesquisa...",
         "showMessage": "Mostrar todos",
-        "title": "Filtros Ativos"
+        "title": "Filtros Ativos - %d"
     },
     "searchPlaceholder": "",
     "select": {


### PR DESCRIPTION
This pull request updates the Portuguese (Brazil) i18n strings for the DataTables SearchPanes module.

Specifically:
- Changed `"title": "Filtros Ativos"` to `"title": "Filtros Ativos - %d"` to correctly display the active filters count.
- Applied this change in:
  - `pt-BR.js`
  - `pt-BR.json`
  - `pt-BR.mjs`
